### PR TITLE
fix(backend): add ownership authorization checks to all endpoints

### DIFF
--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -12,52 +12,12 @@ namespace Giraf.IntegrationTests.Endpoints
     [Collection("IntegrationTests")]
     public class ActivityEndpointTests
     {
-        #region GET /weekplan/ - Get all activities
-
-        [Fact]
-        public async Task GetAllActivities_ReturnsListOfActivities_WhenActivitiesExist()
-        {
-            var factory = new GirafWebApplicationFactory();
-            var seeder = new BaseCaseDb();
-            var scope = factory.Services.CreateScope();
-            factory.SeedDb(scope, seeder);
-            var client = factory.CreateClient();
-            client.AttachClaimsToken(role: "member");
-
-            var response = await client.GetAsync("/weekplan");
-
-            response.EnsureSuccessStatusCode();
-            var activities = await response.Content.ReadFromJsonAsync<List<ActivityDTO>>();
-            Assert.NotNull(activities);
-            Assert.NotEmpty(activities);
-        }
-
-        [Fact]
-        public async Task GetAllActivities_ReturnsEmptyList_WhenNoActivitiesExist()
-        {
-            var factory = new GirafWebApplicationFactory();
-            var seeder = new EmptyDb();
-            var scope = factory.Services.CreateScope();
-            factory.SeedDb(scope, seeder);
-            var client = factory.CreateClient();
-            client.AttachClaimsToken(role: "admin");
-
-            var response = await client.GetAsync("/weekplan");
-
-            response.EnsureSuccessStatusCode();
-            var activities = await response.Content.ReadFromJsonAsync<List<ActivityDTO>>();
-            Assert.NotNull(activities);
-            Assert.Empty(activities);
-        }
-
-        #endregion
-
         #region GET /weekplan/{citizenId:int} - Get activities for a citizen on a date
 
         [Fact]
         public async Task GetActivitiesForCitizenOnDate_ReturnsActivities_WhenActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -74,9 +34,9 @@ namespace Giraf.IntegrationTests.Endpoints
         }
 
         [Fact]
-        public async Task GetActivitiesForCitizenOnDate_ReturnsEmptyList_WhenCitizenDoesNotExist()
+        public async Task GetActivitiesForCitizenOnDate_ReturnsNotFound_WhenCitizenDoesNotExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -86,10 +46,7 @@ namespace Giraf.IntegrationTests.Endpoints
             var date = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
             var response = await client.GetAsync($"/weekplan/999?date={date}");
 
-            response.EnsureSuccessStatusCode();
-            var activities = await response.Content.ReadFromJsonAsync<List<ActivityDTO>>();
-            Assert.NotNull(activities);
-            Assert.Empty(activities);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         #endregion
@@ -99,7 +56,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task GetActivitiesForGradeOnDate_ReturnsActivities_WhenActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -118,7 +75,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task GetActivitiesForGradeOnDate_ReturnsNotFound_WhenNoActivities()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -138,7 +95,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task GetActivityById_ReturnsActivity_WhenActivityExists()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -157,7 +114,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task GetActivityById_ReturnsNotFound_WhenActivityDoesNotExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -218,7 +175,7 @@ namespace Giraf.IntegrationTests.Endpoints
                 PictogramId: null
             );
 
-            // StubCoreClient returns NotFound for id >= 101
+            // StubCoreClient returns NotFound for id >= 201
             var response = await client.PostAsJsonAsync("/weekplan/to-citizen/999", newActivityDto);
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -344,7 +301,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task DeleteActivity_ReturnsNoContent_WhenActivityExists()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -365,7 +322,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task DeleteActivity_ReturnsNotFound_WhenActivityDoesNotExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -384,7 +341,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task SetActivityCompletionStatus_ReturnsOk_WhenActivityExists()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -407,7 +364,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task SetActivityCompletionStatus_ReturnsNotFound_WhenActivityDoesNotExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -470,7 +427,7 @@ namespace Giraf.IntegrationTests.Endpoints
 
             int activityId = seeder.Activities[0].Id;
 
-            // StubCoreClient returns false for id >= 101
+            // StubCoreClient returns NotFound for id >= 201
             var response = await client.PostAsync($"/weekplan/activity/assign-pictogram/{activityId}/999", null);
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -548,7 +505,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task GetActivitiesForCitizenOnDate_ReturnsBadRequest_WhenDateIsInvalid()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -593,7 +550,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task CopyActivityForCitizen_ReturnsOk_WhenActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -621,7 +578,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task CopyActivityForCitizen_ReturnsNotFound_WhenNoActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -646,7 +603,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task CopyActivityForGrade_ReturnsOk_WhenActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -674,7 +631,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task CopyActivityForGrade_ReturnsNotFound_WhenNoActivitiesExist()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -695,21 +652,6 @@ namespace Giraf.IntegrationTests.Endpoints
         #endregion
 
         #region Authentication - Unauthenticated requests
-
-        [Fact]
-        public async Task GetAllActivities_ReturnsUnauthorized_WhenNoToken()
-        {
-            var factory = new GirafWebApplicationFactory();
-            var seeder = new EmptyDb();
-            var scope = factory.Services.CreateScope();
-            factory.SeedDb(scope, seeder);
-            var client = factory.CreateClient();
-            // No token attached
-
-            var response = await client.GetAsync("/weekplan");
-
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        }
 
         [Fact]
         public async Task CreateActivityForCitizen_ReturnsUnauthorized_WhenNoToken()
@@ -736,7 +678,7 @@ namespace Giraf.IntegrationTests.Endpoints
         [Fact]
         public async Task DeleteActivity_ReturnsUnauthorized_WhenNoToken()
         {
-            var factory = new GirafWebApplicationFactory();
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new BaseCaseDb();
             var scope = factory.Services.CreateScope();
             factory.SeedDb(scope, seeder);
@@ -744,6 +686,173 @@ namespace Giraf.IntegrationTests.Endpoints
 
             int activityId = seeder.Activities[0].Id;
             var response = await client.DeleteAsync($"/weekplan/activity/{activityId}");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        #endregion
+
+        #region Authorization - Ownership checks (Forbidden owner returns 401)
+
+        [Fact]
+        public async Task GetActivitiesForCitizen_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var date = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
+            var response = await client.GetAsync($"/weekplan/101?date={date}");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetActivitiesForGrade_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var date = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
+            var response = await client.GetAsync($"/weekplan/grade/101?date={date}");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetActivityById_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new ForbiddenOwnerDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.GetAsync($"/weekplan/activity/{activityId}");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ToggleActivityStatus_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new ForbiddenOwnerDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.PutAsync($"/weekplan/activity/{activityId}/iscomplete?IsComplete=true", null);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteActivity_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new ForbiddenOwnerDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.DeleteAsync($"/weekplan/activity/{activityId}");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateActivity_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new ForbiddenOwnerDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            int activityId = seeder.Activities[0].Id;
+            var updateDto = new UpdateActivityDTO
+            (
+                Date: DateOnly.FromDateTime(DateTime.UtcNow),
+                StartTime: new TimeOnly(9, 0),
+                EndTime: new TimeOnly(10, 0),
+                IsCompleted: false,
+                PictogramId: null
+            );
+
+            var response = await client.PutAsJsonAsync($"/weekplan/activity/{activityId}", updateDto);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task AssignPictogram_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new ForbiddenOwnerDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.PostAsync($"/weekplan/activity/assign-pictogram/{activityId}/1", null);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CopyActivityForCitizen_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var sourceDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            var targetDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd");
+            var activityIds = new List<int>();
+
+            var response = await client.PostAsJsonAsync(
+                $"/weekplan/activity/copy-citizen/101?sourceDate={sourceDate}&targetDate={targetDate}",
+                activityIds);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CopyActivityForGrade_ReturnsUnauthorized_WhenOwnerForbidden()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var sourceDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            var targetDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd");
+            var activityIds = new List<int>();
+
+            var response = await client.PostAsJsonAsync(
+                $"/weekplan/activity/copy-grade/101?sourceDate={sourceDate}&targetDate={targetDate}",
+                activityIds);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }

--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -858,5 +858,66 @@ namespace Giraf.IntegrationTests.Endpoints
         }
 
         #endregion
+
+        #region Authorization - Orphaned activities (fail closed)
+
+        [Fact]
+        public async Task GetActivityById_ReturnsForbidden_WhenActivityHasNoOwner()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new OrphanedActivityDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "admin");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.GetAsync($"/weekplan/activity/{activityId}");
+
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateActivity_ReturnsForbidden_WhenActivityHasNoOwner()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new OrphanedActivityDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "admin");
+
+            int activityId = seeder.Activities[0].Id;
+            var updateDto = new UpdateActivityDTO
+            (
+                Date: DateOnly.FromDateTime(DateTime.UtcNow),
+                StartTime: new TimeOnly(9, 0),
+                EndTime: new TimeOnly(10, 0),
+                IsCompleted: false,
+                PictogramId: null
+            );
+
+            var response = await client.PutAsJsonAsync($"/weekplan/activity/{activityId}", updateDto);
+
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteActivity_ReturnsForbidden_WhenActivityHasNoOwner()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new OrphanedActivityDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "admin");
+
+            int activityId = seeder.Activities[0].Id;
+            var response = await client.DeleteAsync($"/weekplan/activity/{activityId}");
+
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        #endregion
     }
 }

--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -692,10 +692,10 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #endregion
 
-        #region Authorization - Ownership checks (Forbidden owner returns 401)
+        #region Authorization - Ownership checks (Forbidden owner returns 403)
 
         [Fact]
-        public async Task GetActivitiesForCitizen_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task GetActivitiesForCitizen_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
@@ -707,11 +707,11 @@ namespace Giraf.IntegrationTests.Endpoints
             var date = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
             var response = await client.GetAsync($"/weekplan/101?date={date}");
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task GetActivitiesForGrade_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task GetActivitiesForGrade_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
@@ -723,11 +723,11 @@ namespace Giraf.IntegrationTests.Endpoints
             var date = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
             var response = await client.GetAsync($"/weekplan/grade/101?date={date}");
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task GetActivityById_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task GetActivityById_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new ForbiddenOwnerDb();
@@ -739,11 +739,11 @@ namespace Giraf.IntegrationTests.Endpoints
             int activityId = seeder.Activities[0].Id;
             var response = await client.GetAsync($"/weekplan/activity/{activityId}");
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task ToggleActivityStatus_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task ToggleActivityStatus_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new ForbiddenOwnerDb();
@@ -755,11 +755,11 @@ namespace Giraf.IntegrationTests.Endpoints
             int activityId = seeder.Activities[0].Id;
             var response = await client.PutAsync($"/weekplan/activity/{activityId}/iscomplete?IsComplete=true", null);
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task DeleteActivity_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task DeleteActivity_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new ForbiddenOwnerDb();
@@ -771,11 +771,11 @@ namespace Giraf.IntegrationTests.Endpoints
             int activityId = seeder.Activities[0].Id;
             var response = await client.DeleteAsync($"/weekplan/activity/{activityId}");
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task UpdateActivity_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task UpdateActivity_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new ForbiddenOwnerDb();
@@ -796,11 +796,11 @@ namespace Giraf.IntegrationTests.Endpoints
 
             var response = await client.PutAsJsonAsync($"/weekplan/activity/{activityId}", updateDto);
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task AssignPictogram_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task AssignPictogram_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new ForbiddenOwnerDb();
@@ -812,11 +812,11 @@ namespace Giraf.IntegrationTests.Endpoints
             int activityId = seeder.Activities[0].Id;
             var response = await client.PostAsync($"/weekplan/activity/assign-pictogram/{activityId}/1", null);
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task CopyActivityForCitizen_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task CopyActivityForCitizen_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
@@ -833,11 +833,11 @@ namespace Giraf.IntegrationTests.Endpoints
                 $"/weekplan/activity/copy-citizen/101?sourceDate={sourceDate}&targetDate={targetDate}",
                 activityIds);
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         [Fact]
-        public async Task CopyActivityForGrade_ReturnsUnauthorized_WhenOwnerForbidden()
+        public async Task CopyActivityForGrade_ReturnsForbidden_WhenOwnerForbidden()
         {
             var factory = new GirafWebApplicationFactory(stubCoreClient: true);
             var seeder = new EmptyDb();
@@ -854,7 +854,7 @@ namespace Giraf.IntegrationTests.Endpoints
                 $"/weekplan/activity/copy-grade/101?sourceDate={sourceDate}&targetDate={targetDate}",
                 activityIds);
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         #endregion

--- a/backend/Giraf.IntegrationTests/Utils/DbSeeders/ForbiddenOwnerDb.cs
+++ b/backend/Giraf.IntegrationTests/Utils/DbSeeders/ForbiddenOwnerDb.cs
@@ -1,0 +1,15 @@
+using GirafAPI.Data;
+
+namespace Giraf.IntegrationTests.Utils.DbSeeders;
+
+/// <summary>
+/// Seeds an activity owned by citizenId=101, which falls in the StubCoreClient's Forbidden range.
+/// Used to test authorization-failure paths.
+/// </summary>
+public class ForbiddenOwnerDb : DbSeeder
+{
+    public override void SeedData(GirafDbContext dbContext)
+    {
+        SeedCitizenActivity(dbContext, citizenId: 101, pictogramId: 1);
+    }
+}

--- a/backend/Giraf.IntegrationTests/Utils/DbSeeders/OrphanedActivityDb.cs
+++ b/backend/Giraf.IntegrationTests/Utils/DbSeeders/OrphanedActivityDb.cs
@@ -1,0 +1,29 @@
+using GirafAPI.Data;
+using GirafAPI.Entities.Activities;
+
+namespace Giraf.IntegrationTests.Utils.DbSeeders;
+
+/// <summary>
+/// Seeds an activity with no CitizenId and no GradeId (orphaned).
+/// Used to test the fail-closed authorization path.
+/// </summary>
+public class OrphanedActivityDb : DbSeeder
+{
+    public override void SeedData(GirafDbContext dbContext)
+    {
+        var activity = new Activity
+        {
+            Date = DateOnly.FromDateTime(DateTime.UtcNow),
+            StartTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+            EndTime = TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+            IsCompleted = false,
+            CitizenId = null,
+            GradeId = null,
+            PictogramId = 1
+        };
+
+        dbContext.Activities.Add(activity);
+        dbContext.SaveChanges();
+        Activities.Add(activity);
+    }
+}

--- a/backend/Giraf.IntegrationTests/Utils/StubCoreClient.cs
+++ b/backend/Giraf.IntegrationTests/Utils/StubCoreClient.cs
@@ -4,12 +4,17 @@ namespace Giraf.IntegrationTests.Utils;
 
 /// <summary>
 /// Stub CoreClient for integration tests.
-/// Returns Valid for IDs 1-100, NotFound for anything else.
+/// IDs 1-100: Valid, IDs 101-200: Forbidden, everything else: NotFound.
 /// </summary>
 public class StubCoreClient : ICoreClient
 {
     private static CoreValidationResult Check(int id) =>
-        id >= 1 && id <= 100 ? CoreValidationResult.Valid : CoreValidationResult.NotFound;
+        id switch
+        {
+            >= 1 and <= 100 => CoreValidationResult.Valid,
+            >= 101 and <= 200 => CoreValidationResult.Forbidden,
+            _ => CoreValidationResult.NotFound
+        };
 
     public Task<CoreValidationResult> ValidateCitizenAsync(int id, string accessToken, CancellationToken ct = default) =>
         Task.FromResult(Check(id));

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -36,6 +36,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status500InternalServerError);
 
         // GET activities for one day for a grade
@@ -56,6 +57,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -77,6 +79,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces<ActivityDTO>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -101,6 +104,7 @@ public static class ActivityEndpoints
             .Accepts<CreateActivityDTO>("application/json")
             .Produces<ActivityDTO>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -124,6 +128,7 @@ public static class ActivityEndpoints
             .Accepts<CreateActivityDTO>("application/json")
             .Produces<ActivityDTO>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -145,6 +150,7 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK);
 
@@ -165,6 +171,7 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK);
 
@@ -187,6 +194,7 @@ public static class ActivityEndpoints
             .Accepts<UpdateActivityDTO>("application/json")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -210,6 +218,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -231,6 +240,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -252,6 +262,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -18,26 +18,16 @@ public static class ActivityEndpoints
     {
         var group = app.MapGroup("weekplan");
 
-        // GET all activities (mainly for debugging)
-        group.MapGet("/", async Task<IResult> (IActivityService service, CancellationToken ct) =>
-            {
-                var result = await service.GetAllActivitiesAsync(ct);
-                return result.ToHttpResult(v => TypedResults.Ok(v));
-            })
-            .WithName("GetAllActivities")
-            .WithDescription("Gets all activities.")
-            .WithTags("Activities")
-            .RequireAuthorization()
-            .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status500InternalServerError);
-
-
         // GET activities for one day for a citizen
         group.MapGet("/{citizenId:int}", async Task<IResult> (int citizenId, DateOnly date,
-                IActivityService service, CancellationToken ct) =>
+                IActivityService service, HttpContext httpContext, CancellationToken ct) =>
             {
+                var token = GetAccessToken(httpContext);
+                if (token is null)
+                    return TypedResults.Unauthorized();
+
                 var result = await service.GetActivitiesByOwnerAsync(
-                    new ActivityOwner.Citizen(citizenId), date, ct);
+                    new ActivityOwner.Citizen(citizenId), date, token, ct);
                 return result.ToHttpResult(v => TypedResults.Ok(v));
             })
             .WithName("GetActivitiesForCitizenOnDate")
@@ -45,14 +35,19 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status500InternalServerError);
 
         // GET activities for one day for a grade
         group.MapGet("/grade/{gradeId:int}", async Task<IResult> (int gradeId, DateOnly date,
-                IActivityService service, CancellationToken ct) =>
+                IActivityService service, HttpContext httpContext, CancellationToken ct) =>
             {
+                var token = GetAccessToken(httpContext);
+                if (token is null)
+                    return TypedResults.Unauthorized();
+
                 var result = await service.GetActivitiesByOwnerAsync(
-                    new ActivityOwner.Grade(gradeId), date, ct);
+                    new ActivityOwner.Grade(gradeId), date, token, ct);
                 return result.ToHttpResult(v => TypedResults.Ok(v));
             })
             .WithName("GetActivitiesForGradeOnDate")
@@ -60,14 +55,20 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
 
         // GET single activity by ID
-        group.MapGet("/activity/{id:int}", async Task<IResult> (int id, IActivityService service, CancellationToken ct) =>
+        group.MapGet("/activity/{id:int}", async Task<IResult> (int id, IActivityService service,
+                HttpContext httpContext, CancellationToken ct) =>
             {
-                var result = await service.GetActivityByIdAsync(id, ct);
+                var token = GetAccessToken(httpContext);
+                if (token is null)
+                    return TypedResults.Unauthorized();
+
+                var result = await service.GetActivityByIdAsync(id, token, ct);
                 return result.ToHttpResult(v => TypedResults.Ok(v));
             })
             .WithName("GetActivityById")
@@ -75,6 +76,7 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces<ActivityDTO>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -98,6 +100,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Accepts<CreateActivityDTO>("application/json")
             .Produces<ActivityDTO>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
@@ -120,37 +123,48 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Accepts<CreateActivityDTO>("application/json")
             .Produces<ActivityDTO>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
 
         group.MapPost("/activity/copy-citizen/{citizenId:int}",
                 async Task<IResult> (int citizenId, DateOnly sourceDate, DateOnly targetDate, List<int> toCopyIds,
-                    IActivityService service, CancellationToken ct) =>
+                    IActivityService service, HttpContext httpContext, CancellationToken ct) =>
                 {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
                     var result = await service.CopyActivitiesAsync(
-                        new ActivityOwner.Citizen(citizenId), sourceDate, targetDate, toCopyIds, ct);
+                        new ActivityOwner.Citizen(citizenId), sourceDate, targetDate, toCopyIds, token, ct);
                     return result.ToHttpResult(() => TypedResults.Ok("Activities successfully copied."));
                 })
             .WithName("CopyActivityForCitizen")
             .WithDescription("Copies activities between days for a citizen")
             .WithTags("Activities")
             .RequireAuthorization()
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK);
 
         group.MapPost("/activity/copy-grade/{gradeId:int}",
                 async Task<IResult> (int gradeId, DateOnly sourceDate, DateOnly targetDate, List<int> toCopyIds,
-                    IActivityService service, CancellationToken ct) =>
+                    IActivityService service, HttpContext httpContext, CancellationToken ct) =>
                 {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
                     var result = await service.CopyActivitiesAsync(
-                        new ActivityOwner.Grade(gradeId), sourceDate, targetDate, toCopyIds, ct);
+                        new ActivityOwner.Grade(gradeId), sourceDate, targetDate, toCopyIds, token, ct);
                     return result.ToHttpResult(() => TypedResults.Ok("Activities successfully copied."));
                 })
             .WithName("CopyActivityForGrade")
             .WithDescription("Copies activities between days for a grade")
             .WithTags("Activities")
             .RequireAuthorization()
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK);
 
@@ -172,6 +186,7 @@ public static class ActivityEndpoints
             .RequireAuthorization()
             .Accepts<UpdateActivityDTO>("application/json")
             .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -179,9 +194,14 @@ public static class ActivityEndpoints
 
         // PUT IsComplete activity
         group.MapPut("/activity/{id:int}/iscomplete",
-                async Task<IResult> (int id, bool IsComplete, IActivityService service, CancellationToken ct) =>
+                async Task<IResult> (int id, bool IsComplete, IActivityService service,
+                    HttpContext httpContext, CancellationToken ct) =>
                 {
-                    var result = await service.ToggleActivityStatusAsync(id, IsComplete, ct);
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.ToggleActivityStatusAsync(id, IsComplete, token, ct);
                     return result.ToHttpResult(() => TypedResults.Ok());
                 })
             .WithName("CompleteActivity")
@@ -189,14 +209,20 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
 
 
         // DELETE activity
-        group.MapDelete("/activity/{id:int}", async Task<IResult> (int id, IActivityService service, CancellationToken ct) =>
+        group.MapDelete("/activity/{id:int}", async Task<IResult> (int id, IActivityService service,
+                HttpContext httpContext, CancellationToken ct) =>
             {
-                var result = await service.DeleteActivityAsync(id, ct);
+                var token = GetAccessToken(httpContext);
+                if (token is null)
+                    return TypedResults.Unauthorized();
+
+                var result = await service.DeleteActivityAsync(id, token, ct);
                 return result.ToHttpResult(() => TypedResults.NoContent());
             })
             .WithName("DeleteActivity")
@@ -204,6 +230,7 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status500InternalServerError);
@@ -224,6 +251,7 @@ public static class ActivityEndpoints
             .WithTags("Activities")
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -18,19 +18,13 @@ public class ActivityService : IActivityService
         _coreClient = coreClient;
     }
 
-    public async Task<ServiceResult<List<ActivityDTO>>> GetAllActivitiesAsync(CancellationToken ct = default)
-    {
-        var activities = await _db.Activities
-            .Select(a => a.ToDTO())
-            .AsNoTracking()
-            .ToListAsync(ct);
-
-        return ServiceResult<List<ActivityDTO>>.Success(activities);
-    }
-
     public async Task<ServiceResult<List<ActivityDTO>>> GetActivitiesByOwnerAsync(
-        ActivityOwner owner, DateOnly date, CancellationToken ct = default)
+        ActivityOwner owner, DateOnly date, string accessToken, CancellationToken ct = default)
     {
+        var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+        if (ownerResult is not null)
+            return ServiceResult<List<ActivityDTO>>.Fail(ownerResult);
+
         var activities = await _db.Activities
             .Where(owner.ToFilter())
             .Where(a => a.Date == date)
@@ -44,16 +38,25 @@ public class ActivityService : IActivityService
             : ServiceResult<List<ActivityDTO>>.Success(activities);
     }
 
-    public async Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, CancellationToken ct = default)
+    public async Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, string accessToken, CancellationToken ct = default)
     {
         var activity = await _db.Activities
             .AsNoTracking()
             .FirstOrDefaultAsync(a => a.Id == id, ct);
 
-        return activity is null
-            ? ServiceResult<ActivityDTO>.Fail(
-                new ServiceError(ServiceErrorKind.NotFound, "Activity not found."))
-            : ServiceResult<ActivityDTO>.Success(activity.ToDTO());
+        if (activity is null)
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+
+        var owner = ResolveOwner(activity);
+        if (owner is not null)
+        {
+            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+            if (ownerResult is not null)
+                return ServiceResult<ActivityDTO>.Fail(ownerResult);
+        }
+
+        return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
 
     public async Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
@@ -94,6 +97,14 @@ public class ActivityService : IActivityService
         if (activity is null)
             return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
+        var owner = ResolveOwner(activity);
+        if (owner is not null)
+        {
+            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+            if (ownerResult is not null)
+                return ServiceResult.Fail(ownerResult);
+        }
+
         if (dto.PictogramId is not null)
         {
             var picResult = await _coreClient.ValidatePictogramAsync(dto.PictogramId.Value, accessToken, ct);
@@ -111,11 +122,19 @@ public class ActivityService : IActivityService
         return ServiceResult.Success();
     }
 
-    public async Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, CancellationToken ct = default)
+    public async Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, string accessToken, CancellationToken ct = default)
     {
         var activity = await _db.Activities.FindAsync([id], ct);
         if (activity is null)
             return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+
+        var owner = ResolveOwner(activity);
+        if (owner is not null)
+        {
+            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+            if (ownerResult is not null)
+                return ServiceResult.Fail(ownerResult);
+        }
 
         activity.IsCompleted = isComplete;
         await _db.SaveChangesAsync(ct);
@@ -123,12 +142,23 @@ public class ActivityService : IActivityService
         return ServiceResult.Success();
     }
 
-    public async Task<ServiceResult> DeleteActivityAsync(int id, CancellationToken ct = default)
+    public async Task<ServiceResult> DeleteActivityAsync(int id, string accessToken, CancellationToken ct = default)
     {
-        var rowsAffected = await _db.Activities.Where(a => a.Id == id).ExecuteDeleteAsync(ct);
-        return rowsAffected == 0
-            ? ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."))
-            : ServiceResult.Success();
+        var activity = await _db.Activities.FindAsync([id], ct);
+        if (activity is null)
+            return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+
+        var owner = ResolveOwner(activity);
+        if (owner is not null)
+        {
+            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+            if (ownerResult is not null)
+                return ServiceResult.Fail(ownerResult);
+        }
+
+        _db.Activities.Remove(activity);
+        await _db.SaveChangesAsync(ct);
+        return ServiceResult.Success();
     }
 
     public async Task<ServiceResult<ActivityDTO>> AssignPictogramAsync(
@@ -138,6 +168,14 @@ public class ActivityService : IActivityService
         if (activity is null)
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+
+        var owner = ResolveOwner(activity);
+        if (owner is not null)
+        {
+            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+            if (ownerResult is not null)
+                return ServiceResult<ActivityDTO>.Fail(ownerResult);
+        }
 
         var picResult = await _coreClient.ValidatePictogramAsync(pictogramId, accessToken, ct);
         if (picResult is not CoreValidationResult.Valid)
@@ -150,8 +188,12 @@ public class ActivityService : IActivityService
     }
 
     public async Task<ServiceResult> CopyActivitiesAsync(
-        ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, CancellationToken ct = default)
+        ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, string accessToken, CancellationToken ct = default)
     {
+        var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+        if (ownerResult is not null)
+            return ServiceResult.Fail(ownerResult);
+
         var activities = await _db.Activities
             .Where(owner.ToFilter())
             .Where(a => a.Date == sourceDate || activityIds.Contains(a.Id))
@@ -179,6 +221,14 @@ public class ActivityService : IActivityService
         await _db.SaveChangesAsync(ct);
         return ServiceResult.Success();
     }
+
+    private static ActivityOwner? ResolveOwner(Activity activity) =>
+        activity switch
+        {
+            { CitizenId: int citizenId } => new ActivityOwner.Citizen(citizenId),
+            { GradeId: int gradeId } => new ActivityOwner.Grade(gradeId),
+            _ => null
+        };
 
     private async Task<ServiceError?> ValidateOwnerAsync(ActivityOwner owner, string accessToken, CancellationToken ct)
     {

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -210,7 +210,7 @@ public class ActivityService : IActivityService
     {
         var owner = ResolveOwner(activity);
         if (owner is null)
-            return new ServiceError(ServiceErrorKind.Internal, "Activity has no resolvable owner.");
+            return new ServiceError(ServiceErrorKind.Forbidden, "Access denied.");
 
         return await ValidateOwnerAsync(owner, accessToken, ct);
     }

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -48,13 +48,9 @@ public class ActivityService : IActivityService
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
-        var owner = ResolveOwner(activity);
-        if (owner is not null)
-        {
-            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
-            if (ownerResult is not null)
-                return ServiceResult<ActivityDTO>.Fail(ownerResult);
-        }
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult<ActivityDTO>.Fail(ownerError);
 
         return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
@@ -97,13 +93,9 @@ public class ActivityService : IActivityService
         if (activity is null)
             return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
-        var owner = ResolveOwner(activity);
-        if (owner is not null)
-        {
-            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
-            if (ownerResult is not null)
-                return ServiceResult.Fail(ownerResult);
-        }
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult.Fail(ownerError);
 
         if (dto.PictogramId is not null)
         {
@@ -128,13 +120,9 @@ public class ActivityService : IActivityService
         if (activity is null)
             return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
-        var owner = ResolveOwner(activity);
-        if (owner is not null)
-        {
-            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
-            if (ownerResult is not null)
-                return ServiceResult.Fail(ownerResult);
-        }
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult.Fail(ownerError);
 
         activity.IsCompleted = isComplete;
         await _db.SaveChangesAsync(ct);
@@ -148,13 +136,9 @@ public class ActivityService : IActivityService
         if (activity is null)
             return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
-        var owner = ResolveOwner(activity);
-        if (owner is not null)
-        {
-            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
-            if (ownerResult is not null)
-                return ServiceResult.Fail(ownerResult);
-        }
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult.Fail(ownerError);
 
         _db.Activities.Remove(activity);
         await _db.SaveChangesAsync(ct);
@@ -169,13 +153,9 @@ public class ActivityService : IActivityService
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
-        var owner = ResolveOwner(activity);
-        if (owner is not null)
-        {
-            var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
-            if (ownerResult is not null)
-                return ServiceResult<ActivityDTO>.Fail(ownerResult);
-        }
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult<ActivityDTO>.Fail(ownerError);
 
         var picResult = await _coreClient.ValidatePictogramAsync(pictogramId, accessToken, ct);
         if (picResult is not CoreValidationResult.Valid)
@@ -222,6 +202,19 @@ public class ActivityService : IActivityService
         return ServiceResult.Success();
     }
 
+    /// <summary>
+    /// Resolves the owner from an activity entity and validates access via giraf-core.
+    /// Fails closed: activities with no resolvable owner are rejected.
+    /// </summary>
+    private async Task<ServiceError?> ValidateActivityOwnerAsync(Activity activity, string accessToken, CancellationToken ct)
+    {
+        var owner = ResolveOwner(activity);
+        if (owner is null)
+            return new ServiceError(ServiceErrorKind.Internal, "Activity has no resolvable owner.");
+
+        return await ValidateOwnerAsync(owner, accessToken, ct);
+    }
+
     private static ActivityOwner? ResolveOwner(Activity activity) =>
         activity switch
         {
@@ -252,7 +245,7 @@ public class ActivityService : IActivityService
     private static ServiceError ToCoreError(CoreValidationResult result, string entity) =>
         result switch
         {
-            CoreValidationResult.Forbidden => new ServiceError(ServiceErrorKind.Unauthorized, $"Not authorized to access {entity.ToLowerInvariant()}."),
+            CoreValidationResult.Forbidden => new ServiceError(ServiceErrorKind.Forbidden, $"Not authorized to access {entity.ToLowerInvariant()}."),
             _ => new ServiceError(ServiceErrorKind.NotFound, $"{entity} not found.")
         };
 }

--- a/backend/GirafAPI/Services/IActivityService.cs
+++ b/backend/GirafAPI/Services/IActivityService.cs
@@ -5,9 +5,8 @@ namespace GirafAPI.Services;
 
 public interface IActivityService
 {
-    Task<ServiceResult<List<ActivityDTO>>> GetAllActivitiesAsync(CancellationToken ct = default);
-    Task<ServiceResult<List<ActivityDTO>>> GetActivitiesByOwnerAsync(ActivityOwner owner, DateOnly date, CancellationToken ct = default);
-    Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, CancellationToken ct = default);
+    Task<ServiceResult<List<ActivityDTO>>> GetActivitiesByOwnerAsync(ActivityOwner owner, DateOnly date, string accessToken, CancellationToken ct = default);
+    Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, string accessToken, CancellationToken ct = default);
 
     Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
         ActivityOwner owner, CreateActivityDTO dto, string accessToken, CancellationToken ct = default);
@@ -15,12 +14,12 @@ public interface IActivityService
     Task<ServiceResult> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default);
 
-    Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, CancellationToken ct = default);
-    Task<ServiceResult> DeleteActivityAsync(int id, CancellationToken ct = default);
+    Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, string accessToken, CancellationToken ct = default);
+    Task<ServiceResult> DeleteActivityAsync(int id, string accessToken, CancellationToken ct = default);
 
     Task<ServiceResult<ActivityDTO>> AssignPictogramAsync(
         int activityId, int pictogramId, string accessToken, CancellationToken ct = default);
 
     Task<ServiceResult> CopyActivitiesAsync(
-        ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, CancellationToken ct = default);
+        ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, string accessToken, CancellationToken ct = default);
 }

--- a/backend/GirafAPI/Services/ServiceResult.cs
+++ b/backend/GirafAPI/Services/ServiceResult.cs
@@ -36,6 +36,7 @@ public enum ServiceErrorKind
     NotFound,
     Validation,
     Unauthorized,
+    Forbidden,
     Conflict,
     Internal
 }

--- a/backend/GirafAPI/Services/ServiceResultExtensions.cs
+++ b/backend/GirafAPI/Services/ServiceResultExtensions.cs
@@ -19,7 +19,7 @@ public static class ServiceResultExtensions
             ServiceErrorKind.NotFound => TypedResults.NotFound(error.Message),
             ServiceErrorKind.Validation => TypedResults.BadRequest(error.Message),
             ServiceErrorKind.Unauthorized => TypedResults.Unauthorized(),
-            ServiceErrorKind.Forbidden => TypedResults.Json(error.Message, statusCode: StatusCodes.Status403Forbidden),
+            ServiceErrorKind.Forbidden => TypedResults.Problem(error.Message, statusCode: StatusCodes.Status403Forbidden),
             _ => TypedResults.Problem(error.Message,
                 statusCode: StatusCodes.Status500InternalServerError)
         };

--- a/backend/GirafAPI/Services/ServiceResultExtensions.cs
+++ b/backend/GirafAPI/Services/ServiceResultExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceResultExtensions
             ServiceErrorKind.NotFound => TypedResults.NotFound(error.Message),
             ServiceErrorKind.Validation => TypedResults.BadRequest(error.Message),
             ServiceErrorKind.Unauthorized => TypedResults.Unauthorized(),
+            ServiceErrorKind.Forbidden => TypedResults.Json(error.Message, statusCode: StatusCodes.Status403Forbidden),
             _ => TypedResults.Problem(error.Message,
                 statusCode: StatusCodes.Status500InternalServerError)
         };


### PR DESCRIPTION
## Summary
- Adds ownership authorization checks to all activity endpoints
- Uses 403 Forbidden for ownership failures instead of 404
- Fails closed on orphaned activities (no owner found)

## Commits
- `ec2d9a4` add ownership authorization checks to all endpoints
- `48a2d85` use 403 Forbidden for ownership failures, fail closed on orphaned activities