### PR TITLE
fix: return updated activity DTO from PUT endpoint

### DIFF
--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -263,11 +263,13 @@ namespace Giraf.IntegrationTests.Endpoints
 
             response.EnsureSuccessStatusCode();
 
-            using var verificationScope = factory.Services.CreateScope();
-            var dbContext = verificationScope.ServiceProvider.GetRequiredService<GirafDbContext>();
-            var updatedActivity = await dbContext.Activities.FindAsync(activityId);
-            Assert.NotNull(updatedActivity);
-            Assert.True(updatedActivity.IsCompleted);
+            var returnedActivity = await response.Content.ReadFromJsonAsync<ActivityDTO>();
+            Assert.NotNull(returnedActivity);
+            Assert.Equal(activityId, returnedActivity.ActivityId);
+            Assert.True(returnedActivity.IsCompleted);
+            Assert.Equal(updateActivityDto.Date, returnedActivity.Date);
+            Assert.Equal(updateActivityDto.StartTime, returnedActivity.StartTime);
+            Assert.Equal(updateActivityDto.EndTime, returnedActivity.EndTime);
         }
 
         [Fact]

--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -270,6 +270,7 @@ namespace Giraf.IntegrationTests.Endpoints
             Assert.Equal(updateActivityDto.Date, returnedActivity.Date);
             Assert.Equal(updateActivityDto.StartTime, returnedActivity.StartTime);
             Assert.Equal(updateActivityDto.EndTime, returnedActivity.EndTime);
+            Assert.Equal(updateActivityDto.PictogramId, returnedActivity.PictogramId);
         }
 
         [Fact]

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -185,14 +185,14 @@ public static class ActivityEndpoints
                         return TypedResults.Unauthorized();
 
                     var result = await service.UpdateActivityAsync(id, dto, token, ct);
-                    return result.ToHttpResult(() => TypedResults.Ok());
+                    return result.ToHttpResult(v => TypedResults.Ok(v));
                 })
             .WithName("UpdateActivity")
             .WithDescription("Updates an existing activity using ID.")
             .WithTags("Activities")
             .RequireAuthorization()
             .Accepts<UpdateActivityDTO>("application/json")
-            .Produces(StatusCodes.Status200OK)
+            .Produces<ActivityDTO>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -82,26 +82,26 @@ public class ActivityService : IActivityService
         return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
 
-    public async Task<ServiceResult> UpdateActivityAsync(
+    public async Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {
         if (dto.EndTime <= dto.StartTime)
-            return ServiceResult.Fail(
+            return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));
 
         var activity = await _db.Activities.FindAsync([id], ct);
         if (activity is null)
-            return ServiceResult.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+            return ServiceResult<ActivityDTO>.Fail(new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
 
         var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
         if (ownerError is not null)
-            return ServiceResult.Fail(ownerError);
+            return ServiceResult<ActivityDTO>.Fail(ownerError);
 
         if (dto.PictogramId is not null)
         {
             var picResult = await _coreClient.ValidatePictogramAsync(dto.PictogramId.Value, accessToken, ct);
             if (picResult is not CoreValidationResult.Valid)
-                return ServiceResult.Fail(ToCoreError(picResult, "Pictogram"));
+                return ServiceResult<ActivityDTO>.Fail(ToCoreError(picResult, "Pictogram"));
         }
 
         activity.Date = dto.Date;
@@ -111,7 +111,7 @@ public class ActivityService : IActivityService
         activity.PictogramId = dto.PictogramId;
         await _db.SaveChangesAsync(ct);
 
-        return ServiceResult.Success();
+        return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
 
     public async Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, string accessToken, CancellationToken ct = default)

--- a/backend/GirafAPI/Services/IActivityService.cs
+++ b/backend/GirafAPI/Services/IActivityService.cs
@@ -11,7 +11,7 @@ public interface IActivityService
     Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
         ActivityOwner owner, CreateActivityDTO dto, string accessToken, CancellationToken ct = default);
 
-    Task<ServiceResult> UpdateActivityAsync(
+    Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default);
 
     Task<ServiceResult> ToggleActivityStatusAsync(int id, bool isComplete, string accessToken, CancellationToken ct = default);


### PR DESCRIPTION
## Summary
- PUT `/weekplan/activity/{id}` now returns the updated `ActivityDTO` in the response body instead of an empty 200
- Changed `UpdateActivityAsync` return type from `ServiceResult` to `ServiceResult<ActivityDTO>`
- Updated OpenAPI metadata to declare the response type

Closes #4

## Test plan
- [x] Existing `UpdateActivity_ReturnsOk_WhenActivityExists` test updated to verify response body contains correct DTO
- [x] All 42 integration tests pass