### PR TITLE
fix: sanitize model binding errors to prevent stack trace leaks

### DIFF
--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -651,6 +651,39 @@ namespace Giraf.IntegrationTests.Endpoints
 
         #endregion
 
+        #region Model binding errors - Sanitized responses
+
+        [Fact]
+        public async Task CopyActivityForCitizen_ReturnsBadRequest_WithoutStackTrace_WhenBodyIsWrongType()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var sourceDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            var targetDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd");
+
+            // Send a JSON object instead of the expected List<int>
+            var badBody = new StringContent(
+                """{"sourceDate":"2025-03-19","targetDate":"2025-03-20"}""",
+                System.Text.Encoding.UTF8, "application/json");
+
+            var response = await client.PostAsync(
+                $"/weekplan/activity/copy-citizen/1?sourceDate={sourceDate}&targetDate={targetDate}",
+                badBody);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("StackTrace", body, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("BadHttpRequestException", body, StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
         #region Authentication - Unauthenticated requests
 
         [Fact]

--- a/backend/GirafAPI/Configuration/BadRequestExceptionHandler.cs
+++ b/backend/GirafAPI/Configuration/BadRequestExceptionHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace GirafAPI.Configuration;
 
@@ -8,13 +9,16 @@ namespace GirafAPI.Configuration;
 /// Catches BadHttpRequestException (model binding failures) and returns a clean 400
 /// instead of leaking stack traces or internal type names.
 /// </summary>
-public sealed class BadRequestExceptionHandler : IExceptionHandler
+public sealed class BadRequestExceptionHandler(
+    ILogger<BadRequestExceptionHandler> logger) : IExceptionHandler
 {
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
         if (exception is not BadHttpRequestException badRequest)
             return false;
+
+        logger.LogWarning(badRequest, "Bad request on {Path}", httpContext.Request.Path);
 
         httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
         await httpContext.Response.WriteAsJsonAsync(new ProblemDetails

--- a/backend/GirafAPI/Configuration/BadRequestExceptionHandler.cs
+++ b/backend/GirafAPI/Configuration/BadRequestExceptionHandler.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GirafAPI.Configuration;
+
+/// <summary>
+/// Catches BadHttpRequestException (model binding failures) and returns a clean 400
+/// instead of leaking stack traces or internal type names.
+/// </summary>
+public sealed class BadRequestExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not BadHttpRequestException badRequest)
+            return false;
+
+        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Bad Request",
+            Detail = "The request body could not be parsed. Check that the JSON structure matches the expected format.",
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1"
+        }, cancellationToken);
+
+        return true;
+    }
+}

--- a/backend/GirafAPI/Program.cs
+++ b/backend/GirafAPI/Program.cs
@@ -1,3 +1,4 @@
+using GirafAPI.Configuration;
 using GirafAPI.Data;
 using GirafAPI.Endpoints;
 using GirafAPI.Extensions;
@@ -12,6 +13,9 @@ builder.Services.ConfigureDatabase(builder.Configuration, builder.Environment)
     .ConfigureCoreClient(builder.Configuration)
     .ConfigureApplicationServices()
     .ConfigureOpenApi();
+
+builder.Services.AddExceptionHandler<BadRequestExceptionHandler>();
+builder.Services.AddProblemDetails();
 
 builder.Services.AddCors(options =>
 {
@@ -36,6 +40,7 @@ builder.Services.AddCors(options =>
 var app = builder.Build();
 
 // Configure middleware
+app.UseExceptionHandler();
 app.UseCors();
 app.MapOpenApi();
 app.MapScalarApiReference();


### PR DESCRIPTION
## Summary
- Adds a global `IExceptionHandler` that catches `BadHttpRequestException` (model binding failures) and returns a clean `ProblemDetails` 400 response
- Prevents leaking .NET stack traces and internal type names in error responses
- Applies to all endpoints, not just the copy endpoints mentioned in the issue

Closes #3

## Test plan
- [x] New test: `CopyActivityForCitizen_ReturnsBadRequest_WithoutStackTrace_WhenBodyIsWrongType` verifies no stack trace or internal type names in response
- [x] All 43 integration tests pass