### PR TITLE
fix: refresh activity list after creating or editing an activity

### DIFF
--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -26,7 +26,7 @@ class ActivityFormView extends StatelessWidget {
       body: BlocConsumer<ActivityFormCubit, ActivityFormState>(
         listener: (context, state) {
           if (state is ActivityFormSaved) {
-            context.pop();
+            context.pop(true);
           }
         },
         builder: (context, state) {

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -29,10 +29,13 @@ class WeekplanView extends StatelessWidget {
         title: const Text('Ugeplan'),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          context.go(
+        onPressed: () async {
+          final saved = await context.push<bool>(
             '/weekplan/$citizenId/add?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId',
           );
+          if (saved == true && context.mounted) {
+            context.read<WeekplanCubit>().loadActivities();
+          }
         },
         backgroundColor: context.colorScheme.primary,
         child: Icon(Icons.add, color: context.colorScheme.onPrimary),
@@ -179,12 +182,15 @@ class _ActivityList extends StatelessWidget {
             activity: activity,
             imageUrl: media?.imageUrl,
             soundUrl: media?.soundUrl,
-            onEdit: () {
-              context.go(
+            onEdit: () async {
+              final saved = await context.push<bool>(
                 '/weekplan/$citizenId/edit/${activity.activityId}'
                 '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId',
                 extra: activity,
               );
+              if (saved == true && context.mounted) {
+                context.read<WeekplanCubit>().loadActivities();
+              }
             },
             onDelete: () => cubit.deleteActivity(activity.activityId),
             onToggleStatus: () =>


### PR DESCRIPTION
## Summary
- Activity list now refreshes automatically after creating or editing an activity
- Changed FAB and edit navigation from `context.go()` to `context.push<bool>()` so the result can be awaited
- Form view pops with `context.pop(true)` to signal a successful save
- On return, `WeekplanCubit.loadActivities()` is called to reload the list

Closes #12

## Test plan
- [x] `flutter analyze` — zero issues
- [x] All 165 Flutter tests pass
- [x] Manual: create activity → list updates immediately on return
- [x] Manual: edit activity → list updates immediately on return