### PR TITLE
fix: harden security — restrict API docs, CORS, and add rate limiting

### DIFF
--- a/backend/GirafAPI/Program.cs
+++ b/backend/GirafAPI/Program.cs
@@ -1,3 +1,4 @@
+using System.Threading.RateLimiting;
 using GirafAPI.Configuration;
 using GirafAPI.Data;
 using GirafAPI.Endpoints;
@@ -21,7 +22,7 @@ builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        if (builder.Environment.IsDevelopment())
+        if (builder.Environment.IsDevelopment() || builder.Environment.IsEnvironment("Testing"))
         {
             policy.AllowAnyOrigin()
                 .AllowAnyHeader()
@@ -29,7 +30,10 @@ builder.Services.AddCors(options =>
         }
         else
         {
-            var origins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>() ?? [];
+            var origins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>();
+            if (origins is null || origins.Length == 0)
+                throw new InvalidOperationException(
+                    "AllowedOrigins must be configured in non-development environments.");
             policy.WithOrigins(origins)
                 .AllowAnyHeader()
                 .AllowAnyMethod();
@@ -37,13 +41,33 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+            }));
+});
+
 var app = builder.Build();
 
 // Configure middleware
 app.UseExceptionHandler();
 app.UseCors();
-app.MapOpenApi();
-app.MapScalarApiReference();
+app.UseRateLimiter();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+    app.MapScalarApiReference();
+}
+
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/backend/GirafAPI/Program.cs
+++ b/backend/GirafAPI/Program.cs
@@ -3,6 +3,7 @@ using GirafAPI.Configuration;
 using GirafAPI.Data;
 using GirafAPI.Endpoints;
 using GirafAPI.Extensions;
+using Microsoft.AspNetCore.HttpOverrides;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -58,6 +59,10 @@ builder.Services.AddRateLimiter(options =>
 var app = builder.Build();
 
 // Configure middleware
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor,
+});
 app.UseExceptionHandler();
 app.UseCors();
 app.UseRateLimiter();
@@ -72,7 +77,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 // Map endpoints
-app.MapGet("/health", () => Results.Ok()).ExcludeFromDescription();
+app.MapGet("/health", () => Results.Ok()).ExcludeFromDescription().DisableRateLimiting();
 app.MapActivityEndpoints();
 
 // Apply migrations


### PR DESCRIPTION
## Summary
- **#13**: OpenAPI spec and Scalar docs now only served in Development — returns 404 in Production/Staging
- **#14**: CORS fails fast with `InvalidOperationException` if `AllowedOrigins` is not configured in non-development environments (prevents silent `Access-Control-Allow-Origin: *`)
- **#15**: Per-IP rate limiting at 60 requests/minute using ASP.NET's built-in `FixedWindowRateLimiter` — returns 429 when exceeded

All changes are in `Program.cs` (1 file, 28 insertions, 4 deletions).

Closes #13, closes #14, closes #15

## Test plan
- [x] All 47 integration tests pass (Testing environment uses permissive CORS, consistent with Development)
- [ ] Manual: verify `/scalar/v1` returns 404 when `ASPNETCORE_ENVIRONMENT=Production`
- [ ] Manual: verify app crashes on startup if `AllowedOrigins` is missing in Production
- [ ] Manual: verify 429 response after 60+ requests in 1 minute from same IP

## Deployment note
The Strato deployment currently uses `ASPNETCORE_ENVIRONMENT=Development` in Docker Compose. To fully activate fixes #13 and #14, the environment should be switched to `Production` in `giraf-deploy` with `AllowedOrigins` configured.