### PR TITLE
refactor: extract TokenManager to decouple AuthCubit from API services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ frontend/.env*.local
 /weekplannerbackend/
 /weekplan-frontend/
 
+# --- Worktrees ---
+.worktrees/
+
 # --- General ---
 .DS_Store
 *.pem

--- a/frontend/integration_test/app_test.dart
+++ b/frontend/integration_test/app_test.dart
@@ -21,6 +21,7 @@ import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
 import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/token_manager.dart';
 
 import '../test/helpers/jwt_test_helper.dart';
 
@@ -30,17 +31,21 @@ class _MockCoreApiService extends Mock implements CoreApiService {}
 
 class _MockActivityApiService extends Mock implements ActivityApiService {}
 
+class _MockTokenManager extends Mock implements TokenManager {}
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   late _MockAuthService mockAuthService;
   late _MockCoreApiService mockCoreApiService;
   late _MockActivityApiService mockActivityApiService;
+  late _MockTokenManager mockTokenManager;
 
   setUp(() {
     mockAuthService = _MockAuthService();
     mockCoreApiService = _MockCoreApiService();
     mockActivityApiService = _MockActivityApiService();
+    mockTokenManager = _MockTokenManager();
 
     // Default stubs: no stored session
     when(() => mockAuthService.getStoredAccessToken())
@@ -61,8 +66,7 @@ void main() {
 
     final authCubit = AuthCubit(
       repository: authRepository,
-      coreApiService: mockCoreApiService,
-      activityApiService: mockActivityApiService,
+      tokenManager: mockTokenManager,
     );
     final refreshListenable = GoRouterRefreshStream(authCubit.stream);
     final orgPickerCubit =
@@ -132,9 +136,8 @@ void main() {
       (_) async => PaginatedResponse<Grade>(items: [], count: 0),
     );
 
-    // Stub token propagation on services (called by AuthCubit.authenticated)
-    when(() => mockCoreApiService.setAuthToken(any())).thenReturn(null);
-    when(() => mockActivityApiService.setAuthToken(any())).thenReturn(null);
+    // Stub token propagation (called by AuthCubit.authenticated via TokenManager)
+    when(() => mockTokenManager.setToken(any())).thenReturn(null);
 
     // Stub activities for citizen 10 (any date string)
     when(() => mockActivityApiService.fetchActivitiesByCitizen(10, any()))

--- a/frontend/lib/features/auth/presentation/auth_cubit.dart
+++ b/frontend/lib/features/auth/presentation/auth_cubit.dart
@@ -3,27 +3,24 @@ import 'package:logging/logging.dart';
 
 import 'package:weekplanner/features/auth/data/repositories/auth_repository.dart';
 import 'package:weekplanner/features/auth/domain/auth_state.dart';
-import 'package:weekplanner/shared/services/activity_api_service.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/token_manager.dart';
 import 'package:weekplanner/shared/utils/jwt_decode.dart';
 
 final _log = Logger('AuthCubit');
 
 /// Manages global authentication state.
 ///
-/// Owns all auth transitions and distributes tokens to API services.
+/// Owns all auth transitions and delegates token distribution
+/// to [TokenManager].
 class AuthCubit extends Cubit<AuthState> {
   final AuthRepository _repository;
-  final CoreApiService _coreApiService;
-  final ActivityApiService _activityApiService;
+  final TokenManager _tokenManager;
 
   AuthCubit({
     required AuthRepository repository,
-    required CoreApiService coreApiService,
-    required ActivityApiService activityApiService,
+    required TokenManager tokenManager,
   })  : _repository = repository,
-        _coreApiService = coreApiService,
-        _activityApiService = activityApiService,
+        _tokenManager = tokenManager,
         super(const AuthUnknown());
 
   /// Whether the current state is [AuthAuthenticated].
@@ -52,11 +49,11 @@ class AuthCubit extends Cubit<AuthState> {
   /// Transition to authenticated state with the given [token].
   ///
   /// Parses the JWT to extract user data and distributes the token
-  /// to API services.
+  /// to API services via [TokenManager].
   void authenticated(String token) {
     final userId = JwtDecode.getUserId(token);
     final orgRoles = JwtDecode.getOrgRoles(token);
-    _distributeToken(token);
+    _tokenManager.setToken(token);
     emit(AuthAuthenticated(
       accessToken: token,
       userId: userId,
@@ -71,17 +68,7 @@ class AuthCubit extends Cubit<AuthState> {
       (failure) => _log.warning('Logout failed: ${failure.message}'),
       (_) {},
     );
-    _clearTokens();
+    _tokenManager.clearToken();
     emit(const AuthUnauthenticated());
-  }
-
-  void _distributeToken(String token) {
-    _coreApiService.setAuthToken(token);
-    _activityApiService.setAuthToken(token);
-  }
-
-  void _clearTokens() {
-    _coreApiService.clearAuthToken();
-    _activityApiService.clearAuthToken();
   }
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
 import 'package:weekplanner/shared/services/core_api_service.dart';
 import 'package:weekplanner/shared/services/log_service.dart';
+import 'package:weekplanner/shared/services/token_manager.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -37,11 +38,15 @@ void main() async {
     coreApiService: coreApiService,
   );
 
+  // Token distribution
+  final tokenManager = TokenManager(
+    consumers: [coreApiService, activityApiService],
+  );
+
   // Auth cubit + router refresh adapter
   final authCubit = AuthCubit(
     repository: authRepository,
-    coreApiService: coreApiService,
-    activityApiService: activityApiService,
+    tokenManager: tokenManager,
   );
   final refreshListenable = GoRouterRefreshStream(authCubit.stream);
 

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -1,8 +1,9 @@
 import 'package:dio/dio.dart';
 import 'package:weekplanner/config/api_config.dart';
 import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/services/token_consumer.dart';
 
-class ActivityApiService {
+class ActivityApiService implements TokenConsumer {
   final Dio _dio;
 
   ActivityApiService({Dio? dio})
@@ -12,10 +13,12 @@ class ActivityApiService {
               headers: {'Content-Type': 'application/json'},
             ));
 
+  @override
   void setAuthToken(String token) {
     _dio.options.headers['Authorization'] = 'Bearer $token';
   }
 
+  @override
   void clearAuthToken() {
     _dio.options.headers.remove('Authorization');
   }

--- a/frontend/lib/shared/services/core_api_service.dart
+++ b/frontend/lib/shared/services/core_api_service.dart
@@ -5,8 +5,9 @@ import 'package:weekplanner/shared/models/grade.dart';
 import 'package:weekplanner/shared/models/organisation.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
+import 'package:weekplanner/shared/services/token_consumer.dart';
 
-class CoreApiService {
+class CoreApiService implements TokenConsumer {
   final Dio _dio;
 
   CoreApiService({Dio? dio})
@@ -34,10 +35,12 @@ class CoreApiService {
     return '${ApiConfig.coreBaseUrl}$url';
   }
 
+  @override
   void setAuthToken(String token) {
     _dio.options.headers['Authorization'] = 'Bearer $token';
   }
 
+  @override
   void clearAuthToken() {
     _dio.options.headers.remove('Authorization');
   }

--- a/frontend/lib/shared/services/token_consumer.dart
+++ b/frontend/lib/shared/services/token_consumer.dart
@@ -1,5 +1,5 @@
 /// Contract for any service that needs an auth token.
-abstract class TokenConsumer {
+abstract interface class TokenConsumer {
   /// Apply the given JWT [token] for authenticated requests.
   void setAuthToken(String token);
 

--- a/frontend/lib/shared/services/token_consumer.dart
+++ b/frontend/lib/shared/services/token_consumer.dart
@@ -1,0 +1,8 @@
+/// Contract for any service that needs an auth token.
+abstract class TokenConsumer {
+  /// Apply the given JWT [token] for authenticated requests.
+  void setAuthToken(String token);
+
+  /// Remove the current auth token.
+  void clearAuthToken();
+}

--- a/frontend/lib/shared/services/token_manager.dart
+++ b/frontend/lib/shared/services/token_manager.dart
@@ -1,0 +1,26 @@
+import 'package:weekplanner/shared/services/token_consumer.dart';
+
+/// Distributes auth tokens to all registered [TokenConsumer]s.
+///
+/// Decouples [AuthCubit] from knowing which services need tokens.
+/// New services only need to be added to the consumer list, satisfying OCP.
+class TokenManager {
+  final List<TokenConsumer> _consumers;
+
+  TokenManager({required List<TokenConsumer> consumers})
+      : _consumers = List.unmodifiable(consumers);
+
+  /// Set the auth token on all registered consumers.
+  void setToken(String token) {
+    for (final consumer in _consumers) {
+      consumer.setAuthToken(token);
+    }
+  }
+
+  /// Clear the auth token from all registered consumers.
+  void clearToken() {
+    for (final consumer in _consumers) {
+      consumer.clearAuthToken();
+    }
+  }
+}

--- a/frontend/lib/shared/services/token_manager.dart
+++ b/frontend/lib/shared/services/token_manager.dart
@@ -2,7 +2,7 @@ import 'package:weekplanner/shared/services/token_consumer.dart';
 
 /// Distributes auth tokens to all registered [TokenConsumer]s.
 ///
-/// Decouples [AuthCubit] from knowing which services need tokens.
+/// Decouples the auth layer from knowing which services need tokens.
 /// New services only need to be added to the consumer list, satisfying OCP.
 class TokenManager {
   final List<TokenConsumer> _consumers;

--- a/frontend/test/features/auth/auth_cubit_test.dart
+++ b/frontend/test/features/auth/auth_cubit_test.dart
@@ -6,33 +6,27 @@ import 'package:weekplanner/core/errors/auth_failure.dart';
 import 'package:weekplanner/features/auth/data/repositories/auth_repository.dart';
 import 'package:weekplanner/features/auth/domain/auth_state.dart';
 import 'package:weekplanner/features/auth/presentation/auth_cubit.dart';
-import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/token_manager.dart';
 
 import '../../helpers/jwt_test_helper.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
-class MockCoreApiService extends Mock implements CoreApiService {}
-
-class MockActivityApiService extends Mock implements ActivityApiService {}
+class MockTokenManager extends Mock implements TokenManager {}
 
 void main() {
   late MockAuthRepository mockRepo;
-  late MockCoreApiService mockCoreApi;
-  late MockActivityApiService mockActivityApi;
+  late MockTokenManager mockTokenManager;
 
   setUp(() {
     mockRepo = MockAuthRepository();
-    mockCoreApi = MockCoreApiService();
-    mockActivityApi = MockActivityApiService();
+    mockTokenManager = MockTokenManager();
   });
 
   AuthCubit buildCubit() => AuthCubit(
         repository: mockRepo,
-        coreApiService: mockCoreApi,
-        activityApiService: mockActivityApi,
+        tokenManager: mockTokenManager,
       );
 
   group('initial state', () {
@@ -51,15 +45,13 @@ void main() {
         final token = createValidJwt();
         when(() => mockRepo.tryGetStoredToken())
             .thenAnswer((_) async => Right(token));
-        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
+        when(() => mockTokenManager.setToken(any())).thenReturn(null);
       },
       build: buildCubit,
       act: (cubit) => cubit.tryRestoreSession(),
       expect: () => [isA<AuthAuthenticated>()],
       verify: (_) {
-        verify(() => mockCoreApi.setAuthToken(any())).called(1);
-        verify(() => mockActivityApi.setAuthToken(any())).called(1);
+        verify(() => mockTokenManager.setToken(any())).called(1);
       },
     );
 
@@ -73,8 +65,7 @@ void main() {
           (_) async => Right(
               AuthTokens(access: token, refresh: 'refresh', orgRoles: {})),
         );
-        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
+        when(() => mockTokenManager.setToken(any())).thenReturn(null);
       },
       build: buildCubit,
       act: (cubit) => cubit.tryRestoreSession(),
@@ -97,10 +88,9 @@ void main() {
 
   group('authenticated', () {
     blocTest<AuthCubit, AuthState>(
-      'emits AuthAuthenticated and distributes token',
+      'emits AuthAuthenticated and distributes token via TokenManager',
       setUp: () {
-        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
+        when(() => mockTokenManager.setToken(any())).thenReturn(null);
       },
       build: buildCubit,
       act: (cubit) => cubit.authenticated(createValidJwt()),
@@ -110,22 +100,19 @@ void main() {
             .having((s) => s.orgRoles, 'orgRoles', {'1': 'admin'}),
       ],
       verify: (_) {
-        verify(() => mockCoreApi.setAuthToken(any())).called(1);
-        verify(() => mockActivityApi.setAuthToken(any())).called(1);
+        verify(() => mockTokenManager.setToken(any())).called(1);
       },
     );
   });
 
   group('logout', () {
     blocTest<AuthCubit, AuthState>(
-      'emits AuthUnauthenticated and clears tokens',
+      'emits AuthUnauthenticated and clears tokens via TokenManager',
       setUp: () {
         when(() => mockRepo.logout())
             .thenAnswer((_) async => const Right(unit));
-        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockCoreApi.clearAuthToken()).thenReturn(null);
-        when(() => mockActivityApi.clearAuthToken()).thenReturn(null);
+        when(() => mockTokenManager.setToken(any())).thenReturn(null);
+        when(() => mockTokenManager.clearToken()).thenReturn(null);
       },
       build: buildCubit,
       seed: () {
@@ -140,8 +127,7 @@ void main() {
       expect: () => [const AuthUnauthenticated()],
       verify: (_) {
         verify(() => mockRepo.logout()).called(1);
-        verify(() => mockCoreApi.clearAuthToken()).called(1);
-        verify(() => mockActivityApi.clearAuthToken()).called(1);
+        verify(() => mockTokenManager.clearToken()).called(1);
       },
     );
   });

--- a/frontend/test/shared/services/token_manager_test.dart
+++ b/frontend/test/shared/services/token_manager_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:weekplanner/shared/services/token_consumer.dart';
+import 'package:weekplanner/shared/services/token_manager.dart';
+
+class MockTokenConsumer extends Mock implements TokenConsumer {}
+
+void main() {
+  group('TokenManager', () {
+    test('setToken calls setAuthToken on all consumers', () {
+      final consumer1 = MockTokenConsumer();
+      final consumer2 = MockTokenConsumer();
+      final manager = TokenManager(consumers: [consumer1, consumer2]);
+
+      manager.setToken('test-token');
+
+      verify(() => consumer1.setAuthToken('test-token')).called(1);
+      verify(() => consumer2.setAuthToken('test-token')).called(1);
+    });
+
+    test('clearToken calls clearAuthToken on all consumers', () {
+      final consumer1 = MockTokenConsumer();
+      final consumer2 = MockTokenConsumer();
+      final manager = TokenManager(consumers: [consumer1, consumer2]);
+
+      manager.clearToken();
+
+      verify(() => consumer1.clearAuthToken()).called(1);
+      verify(() => consumer2.clearAuthToken()).called(1);
+    });
+
+    test('works with empty consumer list', () {
+      final manager = TokenManager(consumers: []);
+
+      // Should not throw
+      manager.setToken('test-token');
+      manager.clearToken();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #25

- Extract `TokenConsumer` abstract class and `TokenManager` to decouple `AuthCubit` from knowing about individual API services
- `AuthCubit` now depends only on `AuthRepository` + `TokenManager` (was: `AuthRepository` + `CoreApiService` + `ActivityApiService`)
- New API services can be added by registering them as `TokenConsumer`s in `main.dart` — no changes to `AuthCubit` needed (OCP)

## Changes

| File | Change |
|------|--------|
| `lib/shared/services/token_consumer.dart` | New — abstract class defining `setAuthToken`/`clearAuthToken` contract |
| `lib/shared/services/token_manager.dart` | New — distributes tokens to all registered consumers |
| `lib/shared/services/core_api_service.dart` | Implements `TokenConsumer`, adds `@override` annotations |
| `lib/shared/services/activity_api_service.dart` | Implements `TokenConsumer`, adds `@override` annotations |
| `lib/features/auth/presentation/auth_cubit.dart` | Depends on `TokenManager` instead of individual services |
| `lib/main.dart` | Wires `TokenManager` with both services as consumers |
| `test/features/auth/auth_cubit_test.dart` | Uses `MockTokenManager` instead of individual service mocks |
| `test/shared/services/token_manager_test.dart` | New — unit tests for `TokenManager` |
| `integration_test/app_test.dart` | Updated to wire `TokenManager` |

## Test plan

- [x] `flutter test` — 168 tests passing (165 existing + 3 new)
- [x] `dart analyze` — zero issues
- [x] `AuthCubit` no longer imports any API service class
- [x] Token distribution still works (verified by existing test coverage)