### PR TITLE
feat: implement JWT token refresh with automatic retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ frontend/.env*.local
 /weekplannerbackend/
 /weekplan-frontend/
 
+# --- Worktrees ---
+.worktrees/
+
 # --- General ---
 .DS_Store
 *.pem

--- a/frontend/lib/features/auth/data/repositories/auth_repository.dart
+++ b/frontend/lib/features/auth/data/repositories/auth_repository.dart
@@ -62,6 +62,24 @@ class AuthRepository {
     }
   }
 
+  /// Try to refresh the access token using the stored refresh token.
+  Future<Either<AuthFailure, String>> tryRefreshToken() async {
+    try {
+      final refreshToken = await _authService.getStoredRefreshToken();
+      if (refreshToken == null) {
+        return Left(UnexpectedFailure('No refresh token'));
+      }
+      final newAccess =
+          await _authService.refreshAccessToken(refreshToken);
+      return Right(newAccess);
+    } on DioException catch (e, stackTrace) {
+      return Left(_mapDioError(e, stackTrace));
+    } catch (e, stackTrace) {
+      _log.warning('Token refresh failed', e, stackTrace);
+      return Left(const UnexpectedFailure());
+    }
+  }
+
   /// Clear stored tokens.
   Future<Either<AuthFailure, Unit>> logout() async {
     try {

--- a/frontend/lib/features/auth/presentation/auth_cubit.dart
+++ b/frontend/lib/features/auth/presentation/auth_cubit.dart
@@ -29,8 +29,14 @@ class AuthCubit extends Cubit<AuthState> {
   /// Whether the current state is [AuthAuthenticated].
   bool get isAuthenticated => state is AuthAuthenticated;
 
-  /// Attempt to restore a previous session from stored tokens or credentials.
+  /// Attempt to restore a previous session.
+  ///
+  /// Tries three strategies in order:
+  /// 1. Non-expired stored access token
+  /// 2. Refresh token exchange (access expired but refresh still valid)
+  /// 3. Auto-login with saved credentials
   Future<void> tryRestoreSession() async {
+    // 1. Try non-expired stored access token.
     final tokenResult = await _repository.tryGetStoredToken();
     final restored = tokenResult.fold(
       (_) => false,
@@ -39,9 +45,20 @@ class AuthCubit extends Cubit<AuthState> {
         return true;
       },
     );
-
     if (restored) return;
 
+    // 2. Try refreshing with stored refresh token.
+    final refreshResult = await _repository.tryRefreshToken();
+    final refreshed = refreshResult.fold(
+      (_) => false,
+      (token) {
+        authenticated(token);
+        return true;
+      },
+    );
+    if (refreshed) return;
+
+    // 3. Fall back to saved credentials.
     final autoLoginResult = await _repository.tryAutoLogin();
     autoLoginResult.fold(
       (_) => emit(const AuthUnauthenticated()),

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,8 +1,11 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:provider/provider.dart';
 
 import 'package:weekplanner/app.dart';
+import 'package:weekplanner/config/api_config.dart';
 import 'package:weekplanner/core/routing/go_router_refresh_stream.dart';
 import 'package:weekplanner/features/auth/data/repositories/auth_repository.dart';
 import 'package:weekplanner/features/auth/presentation/auth_cubit.dart';
@@ -11,6 +14,7 @@ import 'package:weekplanner/features/organisation_picker/data/repositories/organ
 import 'package:weekplanner/features/organisation_picker/presentation/organisation_picker_cubit.dart';
 import 'package:weekplanner/features/weekplan/data/repositories/activity_repository.dart';
 import 'package:weekplanner/features/weekplan/data/repositories/pictogram_repository.dart';
+import 'package:weekplanner/shared/interceptors/token_refresh_interceptor.dart';
 import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
 import 'package:weekplanner/shared/services/core_api_service.dart';
@@ -20,10 +24,21 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await setupLogging();
 
+  // Dio instances — created here so the refresh interceptor can be shared.
+  // AuthService keeps its own Dio (login 401s should NOT trigger refresh).
+  final coreDio = Dio(BaseOptions(
+    baseUrl: ApiConfig.coreBaseUrl,
+    headers: {'Content-Type': 'application/json'},
+  ));
+  final activityDio = Dio(BaseOptions(
+    baseUrl: ApiConfig.weekplannerBaseUrl,
+    headers: {'Content-Type': 'application/json'},
+  ));
+
   // Services
   final authService = AuthService();
-  final coreApiService = CoreApiService();
-  final activityApiService = ActivityApiService();
+  final coreApiService = CoreApiService(dio: coreDio);
+  final activityApiService = ActivityApiService(dio: activityDio);
 
   // Repositories
   final authRepository = AuthRepository(authService: authService);
@@ -44,6 +59,19 @@ void main() async {
     activityApiService: activityApiService,
   );
   final refreshListenable = GoRouterRefreshStream(authCubit.stream);
+
+  // Token refresh interceptor — handles 401s by refreshing the access token
+  // and retrying the failed request. Shared across core and activity Dio.
+  final refreshDio = Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl));
+  final tokenInterceptor = TokenRefreshInterceptor(
+    refreshDio: refreshDio,
+    storage: const FlutterSecureStorage(),
+    protectedDios: [coreDio, activityDio],
+    onTokenRefreshed: (token) => authCubit.authenticated(token),
+    onRefreshFailed: () => authCubit.logout(),
+  );
+  coreDio.interceptors.add(tokenInterceptor);
+  activityDio.interceptors.add(tokenInterceptor);
 
   // Try to restore session
   authCubit.tryRestoreSession();

--- a/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
+++ b/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logging/logging.dart';
+import 'package:weekplanner/shared/services/auth_service.dart';
 
 final _log = Logger('TokenRefreshInterceptor');
 
@@ -23,8 +24,6 @@ class TokenRefreshInterceptor extends Interceptor {
   final void Function(String token)? onTokenRefreshed;
   final void Function()? onRefreshFailed;
 
-  static const _refreshTokenKey = 'refresh_token';
-  static const _accessTokenKey = 'access_token';
   static const _refreshPath = '/api/v1/token/refresh';
   static const _retryHeader = 'x-token-retry';
 
@@ -62,7 +61,11 @@ class TokenRefreshInterceptor extends Interceptor {
       _log.fine('Refresh already in progress, waiting…');
       final newToken = await _refreshCompleter!.future;
       if (newToken != null) {
-        return handler.resolve(await _retry(err.requestOptions, newToken));
+        try {
+          return handler.resolve(await _retry(err.requestOptions, newToken));
+        } catch (_) {
+          return handler.next(err);
+        }
       }
       return handler.next(err);
     }
@@ -71,7 +74,7 @@ class TokenRefreshInterceptor extends Interceptor {
     _refreshCompleter = Completer<String?>();
 
     try {
-      final refreshToken = await _storage.read(key: _refreshTokenKey);
+      final refreshToken = await _storage.read(key: AuthService.refreshTokenKey);
       if (refreshToken == null) {
         _log.warning('No refresh token in storage');
         _refreshCompleter!.complete(null);
@@ -88,7 +91,7 @@ class TokenRefreshInterceptor extends Interceptor {
           (response.data as Map<String, dynamic>)['access'] as String;
 
       // Persist the new access token.
-      await _storage.write(key: _accessTokenKey, value: newAccessToken);
+      await _storage.write(key: AuthService.accessTokenKey, value: newAccessToken);
 
       // Update all protected Dio instances.
       for (final dio in _protectedDios) {
@@ -128,9 +131,13 @@ class TokenRefreshInterceptor extends Interceptor {
     requestOptions.headers[_retryHeader] = 'true';
 
     // Find the Dio that owns this request based on base URL.
+    final uri = requestOptions.uri.toString();
     final dio = _protectedDios.firstWhere(
-      (d) => requestOptions.uri.toString().startsWith(d.options.baseUrl),
-      orElse: () => _protectedDios.first,
+      (d) => uri.startsWith(d.options.baseUrl),
+      orElse: () {
+        _log.warning('No matching Dio for $uri, using first');
+        return _protectedDios.first;
+      },
     );
     return dio.fetch(requestOptions);
   }

--- a/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
+++ b/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger('TokenRefreshInterceptor');
+
+/// Dio interceptor that transparently refreshes expired access tokens.
+///
+/// When a 401 response is received, the interceptor:
+/// 1. Reads the refresh token from secure storage
+/// 2. Calls the giraf-core token refresh endpoint
+/// 3. Updates all protected Dio instances with the new access token
+/// 4. Retries the original request
+///
+/// Concurrent 401s are serialized: only one refresh attempt runs at a time,
+/// and other requests wait for its result.
+class TokenRefreshInterceptor extends Interceptor {
+  final Dio _refreshDio;
+  final FlutterSecureStorage _storage;
+  final List<Dio> _protectedDios;
+  final void Function(String token)? onTokenRefreshed;
+  final void Function()? onRefreshFailed;
+
+  static const _refreshTokenKey = 'refresh_token';
+  static const _accessTokenKey = 'access_token';
+  static const _refreshPath = '/api/v1/token/refresh';
+  static const _retryHeader = 'x-token-retry';
+
+  bool _isRefreshing = false;
+  Completer<String?>? _refreshCompleter;
+
+  TokenRefreshInterceptor({
+    required Dio refreshDio,
+    required FlutterSecureStorage storage,
+    required List<Dio> protectedDios,
+    this.onTokenRefreshed,
+    this.onRefreshFailed,
+  })  : _refreshDio = refreshDio,
+        _storage = storage,
+        _protectedDios = protectedDios;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode != 401) {
+      return handler.next(err);
+    }
+
+    // Don't intercept the refresh endpoint itself to avoid infinite loops.
+    if (err.requestOptions.path.contains(_refreshPath)) {
+      return handler.next(err);
+    }
+
+    // Don't intercept retried requests (already refreshed).
+    if (err.requestOptions.headers[_retryHeader] == 'true') {
+      return handler.next(err);
+    }
+
+    // If another request is already refreshing, wait for its result.
+    if (_isRefreshing) {
+      _log.fine('Refresh already in progress, waiting…');
+      final newToken = await _refreshCompleter!.future;
+      if (newToken != null) {
+        return handler.resolve(await _retry(err.requestOptions, newToken));
+      }
+      return handler.next(err);
+    }
+
+    _isRefreshing = true;
+    _refreshCompleter = Completer<String?>();
+
+    try {
+      final refreshToken = await _storage.read(key: _refreshTokenKey);
+      if (refreshToken == null) {
+        _log.warning('No refresh token in storage');
+        _refreshCompleter!.complete(null);
+        onRefreshFailed?.call();
+        return handler.next(err);
+      }
+
+      _log.info('Access token expired, attempting refresh…');
+      final response = await _refreshDio.post(
+        _refreshPath,
+        data: {'refresh': refreshToken},
+      );
+      final newAccessToken =
+          (response.data as Map<String, dynamic>)['access'] as String;
+
+      // Persist the new access token.
+      await _storage.write(key: _accessTokenKey, value: newAccessToken);
+
+      // Update all protected Dio instances.
+      for (final dio in _protectedDios) {
+        dio.options.headers['Authorization'] = 'Bearer $newAccessToken';
+      }
+
+      _log.info('Token refreshed successfully');
+      _refreshCompleter!.complete(newAccessToken);
+      onTokenRefreshed?.call(newAccessToken);
+
+      // Retry the original request with the new token.
+      return handler.resolve(await _retry(err.requestOptions, newAccessToken));
+    } on DioException catch (e) {
+      _log.warning('Token refresh failed: ${e.message}');
+      _refreshCompleter!.complete(null);
+      onRefreshFailed?.call();
+      return handler.next(err);
+    } catch (e, stackTrace) {
+      _log.severe('Unexpected error during token refresh', e, stackTrace);
+      _refreshCompleter!.complete(null);
+      onRefreshFailed?.call();
+      return handler.next(err);
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+
+  /// Retry a failed request with a new access token.
+  ///
+  /// Finds the matching protected [Dio] instance by base URL and retries
+  /// through it. A retry header prevents this interceptor from re-triggering.
+  Future<Response<dynamic>> _retry(
+    RequestOptions requestOptions,
+    String newToken,
+  ) async {
+    requestOptions.headers['Authorization'] = 'Bearer $newToken';
+    requestOptions.headers[_retryHeader] = 'true';
+
+    // Find the Dio that owns this request based on base URL.
+    final dio = _protectedDios.firstWhere(
+      (d) => requestOptions.uri.toString().startsWith(d.options.baseUrl),
+      orElse: () => _protectedDios.first,
+    );
+    return dio.fetch(requestOptions);
+  }
+}

--- a/frontend/lib/shared/services/auth_service.dart
+++ b/frontend/lib/shared/services/auth_service.dart
@@ -18,8 +18,12 @@ class AuthService {
   final Dio _dio;
   final FlutterSecureStorage _storage;
 
-  static const _accessKey = 'access_token';
-  static const _refreshKey = 'refresh_token';
+  /// Storage key for the access token. Shared with [TokenRefreshInterceptor].
+  static const accessTokenKey = 'access_token';
+
+  /// Storage key for the refresh token. Shared with [TokenRefreshInterceptor].
+  static const refreshTokenKey = 'refresh_token';
+
   static const _emailKey = 'saved_email';
   static const _passwordKey = 'saved_password';
 
@@ -40,18 +44,18 @@ class AuthService {
               ?.map((k, v) => MapEntry(k, v.toString())) ??
           {},
     );
-    await _storage.write(key: _accessKey, value: tokens.access);
-    await _storage.write(key: _refreshKey, value: tokens.refresh);
+    await _storage.write(key: accessTokenKey, value: tokens.access);
+    await _storage.write(key: refreshTokenKey, value: tokens.refresh);
     return tokens;
   }
 
   Future<void> logout() async {
-    await _storage.delete(key: _accessKey);
-    await _storage.delete(key: _refreshKey);
+    await _storage.delete(key: accessTokenKey);
+    await _storage.delete(key: refreshTokenKey);
   }
 
-  Future<String?> getStoredAccessToken() => _storage.read(key: _accessKey);
-  Future<String?> getStoredRefreshToken() => _storage.read(key: _refreshKey);
+  Future<String?> getStoredAccessToken() => _storage.read(key: accessTokenKey);
+  Future<String?> getStoredRefreshToken() => _storage.read(key: refreshTokenKey);
 
   Future<void> saveCredentials(String email, String password) async {
     await _storage.write(key: _emailKey, value: email);
@@ -80,7 +84,7 @@ class AuthService {
     );
     final newAccess =
         (response.data as Map<String, dynamic>)['access'] as String;
-    await _storage.write(key: _accessKey, value: newAccess);
+    await _storage.write(key: accessTokenKey, value: newAccess);
     return newAccess;
   }
 }

--- a/frontend/lib/shared/services/auth_service.dart
+++ b/frontend/lib/shared/services/auth_service.dart
@@ -68,4 +68,19 @@ class AuthService {
     await _storage.delete(key: _emailKey);
     await _storage.delete(key: _passwordKey);
   }
+
+  /// Exchange a refresh token for a new access token.
+  ///
+  /// Calls giraf-core's `/api/v1/token/refresh` endpoint and persists the
+  /// new access token in secure storage.
+  Future<String> refreshAccessToken(String refreshToken) async {
+    final response = await _dio.post(
+      '/api/v1/token/refresh',
+      data: {'refresh': refreshToken},
+    );
+    final newAccess =
+        (response.data as Map<String, dynamic>)['access'] as String;
+    await _storage.write(key: _accessKey, value: newAccess);
+    return newAccess;
+  }
 }

--- a/frontend/test/features/auth/auth_cubit_test.dart
+++ b/frontend/test/features/auth/auth_cubit_test.dart
@@ -64,10 +64,31 @@ void main() {
     );
 
     blocTest<AuthCubit, AuthState>(
-      'falls back to auto-login when no stored token',
+      'uses refresh token when stored access token is expired',
       setUp: () {
         final token = createValidJwt();
         when(() => mockRepo.tryGetStoredToken())
+            .thenAnswer((_) async => Left(UnexpectedFailure()));
+        when(() => mockRepo.tryRefreshToken())
+            .thenAnswer((_) async => Right(token));
+        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
+        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.tryRestoreSession(),
+      expect: () => [isA<AuthAuthenticated>()],
+      verify: (_) {
+        verifyNever(() => mockRepo.tryAutoLogin());
+      },
+    );
+
+    blocTest<AuthCubit, AuthState>(
+      'falls back to auto-login when stored token and refresh both fail',
+      setUp: () {
+        final token = createValidJwt();
+        when(() => mockRepo.tryGetStoredToken())
+            .thenAnswer((_) async => Left(UnexpectedFailure()));
+        when(() => mockRepo.tryRefreshToken())
             .thenAnswer((_) async => Left(UnexpectedFailure()));
         when(() => mockRepo.tryAutoLogin()).thenAnswer(
           (_) async => Right(
@@ -82,9 +103,11 @@ void main() {
     );
 
     blocTest<AuthCubit, AuthState>(
-      'emits AuthUnauthenticated when both restore paths fail',
+      'emits AuthUnauthenticated when all three restore paths fail',
       setUp: () {
         when(() => mockRepo.tryGetStoredToken())
+            .thenAnswer((_) async => Left(UnexpectedFailure()));
+        when(() => mockRepo.tryRefreshToken())
             .thenAnswer((_) async => Left(UnexpectedFailure()));
         when(() => mockRepo.tryAutoLogin())
             .thenAnswer((_) async => Left(UnexpectedFailure()));

--- a/frontend/test/features/auth/auth_repository_test.dart
+++ b/frontend/test/features/auth/auth_repository_test.dart
@@ -141,6 +141,70 @@ void main() {
     });
   });
 
+  group('tryRefreshToken', () {
+    test('returns Right with new token on success', () async {
+      final newToken = createValidJwt();
+      when(() => mockAuthService.getStoredRefreshToken())
+          .thenAnswer((_) async => 'valid-refresh');
+      when(() => mockAuthService.refreshAccessToken('valid-refresh'))
+          .thenAnswer((_) async => newToken);
+
+      final result = await repo.tryRefreshToken();
+
+      expect(result.isRight(), true);
+      result.fold(
+        (_) => fail('Expected Right'),
+        (token) => expect(token, newToken),
+      );
+    });
+
+    test('returns Left when no refresh token in storage', () async {
+      when(() => mockAuthService.getStoredRefreshToken())
+          .thenAnswer((_) async => null);
+
+      final result = await repo.tryRefreshToken();
+
+      expect(result.isLeft(), true);
+      result.fold(
+        (failure) => expect(failure, isA<UnexpectedFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    test('returns InvalidCredentialsFailure on 401 from refresh', () async {
+      when(() => mockAuthService.getStoredRefreshToken())
+          .thenAnswer((_) async => 'expired-refresh');
+      when(() => mockAuthService.refreshAccessToken('expired-refresh'))
+          .thenThrow(DioException(
+        requestOptions: RequestOptions(),
+        response: Response(requestOptions: RequestOptions(), statusCode: 401),
+      ));
+
+      final result = await repo.tryRefreshToken();
+
+      expect(result.isLeft(), true);
+      result.fold(
+        (failure) => expect(failure, isA<InvalidCredentialsFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
+
+    test('returns UnexpectedFailure on non-Dio exception', () async {
+      when(() => mockAuthService.getStoredRefreshToken())
+          .thenAnswer((_) async => 'some-refresh');
+      when(() => mockAuthService.refreshAccessToken('some-refresh'))
+          .thenThrow(Exception('boom'));
+
+      final result = await repo.tryRefreshToken();
+
+      expect(result.isLeft(), true);
+      result.fold(
+        (failure) => expect(failure, isA<UnexpectedFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
+  });
+
   group('logout', () {
     test('returns Right on success', () async {
       when(() => mockAuthService.logout()).thenAnswer((_) async {});

--- a/frontend/test/shared/interceptors/token_refresh_interceptor_test.dart
+++ b/frontend/test/shared/interceptors/token_refresh_interceptor_test.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:weekplanner/shared/interceptors/token_refresh_interceptor.dart';
+
+import '../../helpers/jwt_test_helper.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+/// An [HttpClientAdapter] that returns canned responses based on a callback.
+class _FakeAdapter implements HttpClientAdapter {
+  final Future<ResponseBody> Function(RequestOptions options) handler;
+
+  _FakeAdapter(this.handler);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) => handler(options);
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  late MockFlutterSecureStorage mockStorage;
+  late Dio refreshDio;
+  late Dio coreDio;
+  late Dio activityDio;
+  late TokenRefreshInterceptor interceptor;
+  late bool tokenRefreshedCalled;
+  late bool refreshFailedCalled;
+  late String? lastRefreshedToken;
+
+  ResponseBody jsonResponse(int statusCode, Map<String, dynamic> data) {
+    return ResponseBody.fromString(
+      json.encode(data),
+      statusCode,
+      headers: {
+        'content-type': ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  setUp(() {
+    mockStorage = MockFlutterSecureStorage();
+    refreshDio = Dio(BaseOptions(baseUrl: 'http://core:8000'));
+    coreDio = Dio(BaseOptions(baseUrl: 'http://core:8000'));
+    activityDio = Dio(BaseOptions(baseUrl: 'http://activity:5171'));
+
+    tokenRefreshedCalled = false;
+    refreshFailedCalled = false;
+    lastRefreshedToken = null;
+
+    interceptor = TokenRefreshInterceptor(
+      refreshDio: refreshDio,
+      storage: mockStorage,
+      protectedDios: [coreDio, activityDio],
+      onTokenRefreshed: (token) {
+        tokenRefreshedCalled = true;
+        lastRefreshedToken = token;
+      },
+      onRefreshFailed: () {
+        refreshFailedCalled = true;
+      },
+    );
+
+    coreDio.interceptors.add(interceptor);
+    activityDio.interceptors.add(interceptor);
+  });
+
+  group('TokenRefreshInterceptor', () {
+    test('passes through non-401 errors', () async {
+      coreDio.httpClientAdapter = _FakeAdapter((_) async {
+        return jsonResponse(500, {'error': 'server error'});
+      });
+
+      expect(
+        () => coreDio.get('/api/v1/organizations'),
+        throwsA(isA<DioException>().having(
+          (e) => e.response?.statusCode,
+          'statusCode',
+          500,
+        )),
+      );
+
+      expect(tokenRefreshedCalled, false);
+      expect(refreshFailedCalled, false);
+    });
+
+    test('refreshes token and retries on 401', () async {
+      final newToken = createValidJwt();
+      var coreCallCount = 0;
+
+      // Core Dio: first call → 401, retry → 200.
+      coreDio.httpClientAdapter = _FakeAdapter((options) async {
+        coreCallCount++;
+        if (coreCallCount == 1) {
+          return jsonResponse(401, {'detail': 'unauthorized'});
+        }
+        return jsonResponse(200, {'ok': true});
+      });
+
+      // Refresh Dio: return new access token.
+      refreshDio.httpClientAdapter = _FakeAdapter((_) async {
+        return jsonResponse(200, {'access': newToken});
+      });
+
+      when(() => mockStorage.read(key: 'refresh_token'))
+          .thenAnswer((_) async => 'valid-refresh-token');
+      when(() => mockStorage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+          )).thenAnswer((_) async {});
+
+      final response = await coreDio.get('/api/v1/organizations');
+
+      expect(response.statusCode, 200);
+      expect(tokenRefreshedCalled, true);
+      expect(lastRefreshedToken, newToken);
+      expect(refreshFailedCalled, false);
+
+      // Headers updated on both Dio instances.
+      expect(
+        coreDio.options.headers['Authorization'],
+        'Bearer $newToken',
+      );
+      expect(
+        activityDio.options.headers['Authorization'],
+        'Bearer $newToken',
+      );
+    });
+
+    test('calls onRefreshFailed when no refresh token in storage', () async {
+      coreDio.httpClientAdapter = _FakeAdapter((_) async {
+        return jsonResponse(401, {'detail': 'unauthorized'});
+      });
+
+      when(() => mockStorage.read(key: 'refresh_token'))
+          .thenAnswer((_) async => null);
+
+      await expectLater(
+        () => coreDio.get('/api/v1/organizations'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(refreshFailedCalled, true);
+      expect(tokenRefreshedCalled, false);
+    });
+
+    test('calls onRefreshFailed when refresh endpoint returns 401', () async {
+      coreDio.httpClientAdapter = _FakeAdapter((_) async {
+        return jsonResponse(401, {'detail': 'unauthorized'});
+      });
+
+      refreshDio.httpClientAdapter = _FakeAdapter((_) async {
+        return jsonResponse(401, {'detail': 'refresh token expired'});
+      });
+
+      when(() => mockStorage.read(key: 'refresh_token'))
+          .thenAnswer((_) async => 'expired-refresh-token');
+
+      await expectLater(
+        () => coreDio.get('/api/v1/organizations'),
+        throwsA(isA<DioException>()),
+      );
+
+      expect(refreshFailedCalled, true);
+      expect(tokenRefreshedCalled, false);
+    });
+
+    test('concurrent 401s only refresh once', () async {
+      final newToken = createValidJwt();
+      var refreshCallCount = 0;
+
+      // Both Dio instances: first call → 401, retry → 200.
+      var coreCallCount = 0;
+      coreDio.httpClientAdapter = _FakeAdapter((_) async {
+        coreCallCount++;
+        if (coreCallCount == 1) {
+          return jsonResponse(401, {'detail': 'unauthorized'});
+        }
+        return jsonResponse(200, {'data': 'core'});
+      });
+
+      var activityCallCount = 0;
+      activityDio.httpClientAdapter = _FakeAdapter((_) async {
+        activityCallCount++;
+        if (activityCallCount == 1) {
+          return jsonResponse(401, {'detail': 'unauthorized'});
+        }
+        return jsonResponse(200, {'data': 'activity'});
+      });
+
+      refreshDio.httpClientAdapter = _FakeAdapter((_) async {
+        refreshCallCount++;
+        // Small delay to simulate network.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return jsonResponse(200, {'access': newToken});
+      });
+
+      when(() => mockStorage.read(key: 'refresh_token'))
+          .thenAnswer((_) async => 'valid-refresh-token');
+      when(() => mockStorage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+          )).thenAnswer((_) async {});
+
+      final results = await Future.wait([
+        coreDio.get('/api/v1/organizations'),
+        activityDio.get('/weekplan/1'),
+      ]);
+
+      expect(results[0].statusCode, 200);
+      expect(results[1].statusCode, 200);
+      expect(refreshCallCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #29

- Adds a `TokenRefreshInterceptor` that catches 401 responses, refreshes the access token via giraf-core's `/api/v1/token/refresh` endpoint, and retries the failed request transparently
- Concurrent 401s are serialized using a `Completer` mutex — only one refresh attempt runs at a time, other requests wait for its result
- `AuthCubit.tryRestoreSession()` now tries the refresh token (7-day lifetime) before falling back to saved credentials, so users whose 1-hour access token expired can resume without re-entering their password
- Dio instances are created centrally in `main.dart` so the interceptor can be shared across both `CoreApiService` and `ActivityApiService`

## Files changed

| File | Change |
|------|--------|
| `lib/shared/interceptors/token_refresh_interceptor.dart` | **New** — Dio interceptor |
| `lib/shared/services/auth_service.dart` | Added `refreshAccessToken()` |
| `lib/features/auth/data/repositories/auth_repository.dart` | Added `tryRefreshToken()` |
| `lib/features/auth/presentation/auth_cubit.dart` | Updated `tryRestoreSession` with refresh path |
| `lib/main.dart` | Centralized Dio creation, wired interceptor |
| `test/shared/interceptors/token_refresh_interceptor_test.dart` | **New** — 5 interceptor tests |
| `test/features/auth/auth_cubit_test.dart` | Updated + added refresh path tests |
| `test/features/auth/auth_repository_test.dart` | Added 4 `tryRefreshToken` tests |

## Test plan

- [x] `dart analyze lib/ test/` — zero issues
- [x] `flutter test` — 175/175 passing (10 new tests)
- [ ] Manual: run full stack, log in, wait >1 hour (or expire token manually), confirm API calls auto-refresh
- [ ] Manual: verify concurrent API calls during refresh don't cause multiple refresh attempts (check logs)
- [ ] Manual: expire the refresh token, confirm user is logged out cleanly and redirected to login