### PR TITLE
fix: guard against null bytes and path in PlatformFile conversion

### DIFF
--- a/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
@@ -90,12 +90,19 @@ class PictogramRepository {
   }
 
   /// Convert a [PlatformFile] to a Dio [MultipartFile].
+  ///
   /// Uses bytes on web (where path is unavailable) and path on native.
+  /// Throws [StateError] if neither bytes nor path is available.
   MultipartFile _toMultipartFile(PlatformFile file) {
     if (file.bytes != null) {
       return MultipartFile.fromBytes(file.bytes!, filename: file.name);
     }
-    // file.path is only available on native platforms
-    return MultipartFile.fromFileSync(file.path!, filename: file.name);
+    if (file.path != null) {
+      return MultipartFile.fromFileSync(file.path!, filename: file.name);
+    }
+    throw StateError(
+      'PlatformFile "${file.name}" has neither bytes nor path — '
+      'cannot convert to MultipartFile',
+    );
   }
 }

--- a/frontend/test/features/auth/auth_cubit_test.dart
+++ b/frontend/test/features/auth/auth_cubit_test.dart
@@ -63,8 +63,7 @@ void main() {
             .thenAnswer((_) async => Left(UnexpectedFailure()));
         when(() => mockRepo.tryRefreshToken())
             .thenAnswer((_) async => Right(token));
-        when(() => mockCoreApi.setAuthToken(any())).thenReturn(null);
-        when(() => mockActivityApi.setAuthToken(any())).thenReturn(null);
+        when(() => mockTokenManager.setToken(any())).thenReturn(null);
       },
       build: buildCubit,
       act: (cubit) => cubit.tryRestoreSession(),

--- a/frontend/test/features/weekplan/pictogram_repository_test.dart
+++ b/frontend/test/features/weekplan/pictogram_repository_test.dart
@@ -193,5 +193,23 @@ void main() {
         (_) => fail('Expected Left'),
       );
     });
+
+    test('returns Left when file has neither bytes nor path', () async {
+      final mockFile = MockPlatformFile();
+      when(() => mockFile.bytes).thenReturn(null);
+      when(() => mockFile.path).thenReturn(null);
+      when(() => mockFile.name).thenReturn('broken.png');
+
+      final result = await repo.uploadPictogram(
+        name: 'Bade',
+        imageFile: mockFile,
+      );
+
+      expect(result, isA<Left<PictogramFailure, Pictogram>>());
+      result.fold(
+        (failure) => expect(failure, isA<CreatePictogramFailure>()),
+        (_) => fail('Expected Left'),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Closes #31

`PictogramRepository._toMultipartFile()` used `file.path!` without checking for null — if a `PlatformFile` had neither `bytes` (web) nor `path` (native), it would crash with `Null check operator used on a null value`.

Now checks both before accessing, and throws a descriptive `StateError` that the existing `try/catch` in `uploadPictogram` handles gracefully, returning `Left(CreatePictogramFailure)`.

Also fixes a merge artifact in `auth_cubit_test.dart` where `mockCoreApi`/`mockActivityApi` were referenced after being removed in #33.

## Test plan

- [x] `dart analyze lib/ test/` — zero issues
- [x] `flutter test` — 179/179 passing (1 new test)
- [x] New test: `uploadPictogram` returns `Left` when file has neither bytes nor path