### PR TITLE
refactor: remove default Dio instantiation from services

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -36,8 +36,13 @@ void main() async {
     headers: {'Content-Type': 'application/json'},
   ));
 
+  // AuthService gets its own Dio without the refresh interceptor —
+  // login 401s must NOT trigger a token refresh cycle.
+  final authDio = Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl));
+  const storage = FlutterSecureStorage();
+
   // Services
-  final authService = AuthService();
+  final authService = AuthService(dio: authDio, storage: storage);
   final coreApiService = CoreApiService(dio: coreDio);
   final activityApiService = ActivityApiService(dio: activityDio);
 
@@ -70,7 +75,7 @@ void main() async {
   final refreshDio = Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl));
   final tokenInterceptor = TokenRefreshInterceptor(
     refreshDio: refreshDio,
-    storage: const FlutterSecureStorage(),
+    storage: storage,
     protectedDios: [coreDio, activityDio],
     onTokenRefreshed: (token) => authCubit.authenticated(token),
     onRefreshFailed: () => authCubit.logout(),

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -21,24 +21,22 @@ import 'package:weekplanner/shared/services/core_api_service.dart';
 import 'package:weekplanner/shared/services/log_service.dart';
 import 'package:weekplanner/shared/services/token_manager.dart';
 
+Dio _createDio(String baseUrl) => Dio(BaseOptions(
+      baseUrl: baseUrl,
+      headers: {'Content-Type': 'application/json'},
+    ));
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await setupLogging();
 
   // Dio instances — created here so the refresh interceptor can be shared.
-  // AuthService keeps its own Dio (login 401s should NOT trigger refresh).
-  final coreDio = Dio(BaseOptions(
-    baseUrl: ApiConfig.coreBaseUrl,
-    headers: {'Content-Type': 'application/json'},
-  ));
-  final activityDio = Dio(BaseOptions(
-    baseUrl: ApiConfig.weekplannerBaseUrl,
-    headers: {'Content-Type': 'application/json'},
-  ));
+  final coreDio = _createDio(ApiConfig.coreBaseUrl);
+  final activityDio = _createDio(ApiConfig.weekplannerBaseUrl);
 
   // AuthService gets its own Dio without the refresh interceptor —
   // login 401s must NOT trigger a token refresh cycle.
-  final authDio = Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl));
+  final authDio = _createDio(ApiConfig.coreBaseUrl);
   const storage = FlutterSecureStorage();
 
   // Services
@@ -72,7 +70,7 @@ void main() async {
 
   // Token refresh interceptor — handles 401s by refreshing the access token
   // and retrying the failed request. Shared across core and activity Dio.
-  final refreshDio = Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl));
+  final refreshDio = _createDio(ApiConfig.coreBaseUrl);
   final tokenInterceptor = TokenRefreshInterceptor(
     refreshDio: refreshDio,
     storage: storage,

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -1,17 +1,11 @@
 import 'package:dio/dio.dart';
-import 'package:weekplanner/config/api_config.dart';
 import 'package:weekplanner/shared/models/activity.dart';
 import 'package:weekplanner/shared/services/token_consumer.dart';
 
 class ActivityApiService implements TokenConsumer {
   final Dio _dio;
 
-  ActivityApiService({Dio? dio})
-      : _dio = dio ??
-            Dio(BaseOptions(
-              baseUrl: ApiConfig.weekplannerBaseUrl,
-              headers: {'Content-Type': 'application/json'},
-            ));
+  ActivityApiService({required Dio dio}) : _dio = dio;
 
   @override
   void setAuthToken(String token) {

--- a/frontend/lib/shared/services/auth_service.dart
+++ b/frontend/lib/shared/services/auth_service.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:weekplanner/config/api_config.dart';
 
 class AuthTokens {
   final String access;
@@ -27,9 +26,9 @@ class AuthService {
   static const _emailKey = 'saved_email';
   static const _passwordKey = 'saved_password';
 
-  AuthService({Dio? dio, FlutterSecureStorage? storage})
-      : _dio = dio ?? Dio(BaseOptions(baseUrl: ApiConfig.coreBaseUrl)),
-        _storage = storage ?? const FlutterSecureStorage();
+  AuthService({required Dio dio, required FlutterSecureStorage storage})
+      : _dio = dio,
+        _storage = storage;
 
   Future<AuthTokens> login(String email, String password) async {
     final response = await _dio.post(

--- a/frontend/lib/shared/services/core_api_service.dart
+++ b/frontend/lib/shared/services/core_api_service.dart
@@ -10,12 +10,7 @@ import 'package:weekplanner/shared/services/token_consumer.dart';
 class CoreApiService implements TokenConsumer {
   final Dio _dio;
 
-  CoreApiService({Dio? dio})
-      : _dio = dio ??
-            Dio(BaseOptions(
-              baseUrl: ApiConfig.coreBaseUrl,
-              headers: {'Content-Type': 'application/json'},
-            ));
+  CoreApiService({required Dio dio}) : _dio = dio;
 
   /// Resolve media URLs on a [Pictogram] to absolute URLs.
   ///


### PR DESCRIPTION
## Summary

- Make `Dio` a **required** constructor parameter in `AuthService`, `CoreApiService`, and `ActivityApiService`
- Make `FlutterSecureStorage` a **required** parameter in `AuthService`
- Create an explicit `authDio` instance in `main.dart` for `AuthService` (no refresh interceptor — intentional)
- Remove unused `ApiConfig` imports from services that no longer create their own Dio

This enforces the DI principle from the project's CLAUDE.md: *"Never instantiate dependencies internally."*

Closes #28

## Test plan

- [x] `dart analyze` — zero warnings on all changed files
- [x] `flutter test` — all 179 tests pass
- [ ] Manual: verify login, org picker, and weekplan views work with the stack running