### PR TITLE
refactor: use typed TimeValue and DateTime in Activity model

### DIFF
--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -3,9 +3,7 @@ import 'package:file_picker/file_picker.dart';
 
 import 'package:weekplanner/shared/models/activity.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
-
-/// Platform-agnostic time-of-day so cubits avoid importing Flutter.
-typedef TimeValue = ({int hour, int minute});
+import 'package:weekplanner/shared/utils/date_utils.dart';
 
 /// Mode for how the user is adding a pictogram.
 enum PictogramMode { search, upload, generate }

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -39,29 +39,12 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
   })  : _activityRepository = activityRepository,
         _pictogramRepository = pictogramRepository,
         super(ActivityFormReady(
-          date: existingActivity != null
-              ? (DateTime.tryParse(existingActivity.date) ?? initialDate)
-              : initialDate,
-          startTime: existingActivity != null
-              ? (_parseTime(existingActivity.startTime) ??
-                  const (hour: 8, minute: 0))
-              : const (hour: 8, minute: 0),
-          endTime: existingActivity != null
-              ? (_parseTime(existingActivity.endTime) ??
-                  const (hour: 9, minute: 0))
-              : const (hour: 9, minute: 0),
+          date: existingActivity?.date ?? initialDate,
+          startTime: existingActivity?.startTime ?? const (hour: 8, minute: 0),
+          endTime: existingActivity?.endTime ?? const (hour: 9, minute: 0),
           selectedPictogramId: existingActivity?.pictogramId,
           existingActivity: existingActivity,
         ));
-
-  static TimeValue? _parseTime(String time) {
-    final parts = time.split(':');
-    if (parts.length < 2) return null;
-    final hour = int.tryParse(parts[0]);
-    final minute = int.tryParse(parts[1]);
-    if (hour == null || minute == null) return null;
-    return (hour: hour, minute: minute);
-  }
 
   // ── Form field setters ────────────────────────────────────
 
@@ -234,10 +217,8 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
     final data = {
       'date': GirafDateUtils.formatQueryDate(s.date),
-      'startTime':
-          '${s.startTime.hour.toString().padLeft(2, '0')}:${s.startTime.minute.toString().padLeft(2, '0')}:00',
-      'endTime':
-          '${s.endTime.hour.toString().padLeft(2, '0')}:${s.endTime.minute.toString().padLeft(2, '0')}:00',
+      'startTime': formatTimeValueForApi(s.startTime),
+      'endTime': formatTimeValueForApi(s.endTime),
       if (s.selectedPictogramId != null) 'pictogramId': s.selectedPictogramId,
     };
 

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -5,8 +5,8 @@ import 'package:go_router/go_router.dart';
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
-import 'package:weekplanner/shared/utils/date_utils.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_selector.dart';
+import 'package:weekplanner/shared/utils/date_utils.dart';
 
 class ActivityFormView extends StatelessWidget {
   const ActivityFormView({

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
+import 'package:weekplanner/shared/utils/date_utils.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_selector.dart';
 
 class ActivityFormView extends StatelessWidget {
@@ -141,7 +142,7 @@ class _TimePicker extends StatelessWidget {
           prefixIcon: const Icon(Icons.access_time),
         ),
         child: Text(
-          '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}',
+          formatTimeValue(time),
           style: Theme.of(context).textTheme.bodyLarge,
         ),
       ),

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/utils/date_utils.dart';
 
 class ActivityListItem extends StatefulWidget {
   final Activity activity;
@@ -145,7 +146,7 @@ class _ActivityListItemState extends State<ActivityListItem> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '${_formatTime(activity.startTime)} - ${_formatTime(activity.endTime)}',
+                          '${formatTimeValue(activity.startTime)} - ${formatTimeValue(activity.endTime)}',
                           style: TextStyle(
                             fontSize: 14,
                             color: context.colorScheme.outline,
@@ -186,12 +187,4 @@ class _ActivityListItemState extends State<ActivityListItem> {
     );
   }
 
-  String _formatTime(String time) {
-    // Time comes as "HH:mm:ss" or "HH:mm", return "HH:mm"
-    final parts = time.split(':');
-    if (parts.length >= 2) {
-      return '${parts[0]}:${parts[1]}';
-    }
-    return time;
-  }
 }

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -186,5 +186,4 @@ class _ActivityListItemState extends State<ActivityListItem> {
       ),
     );
   }
-
 }

--- a/frontend/lib/shared/models/activity.dart
+++ b/frontend/lib/shared/models/activity.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'package:weekplanner/shared/utils/date_utils.dart';
+
 part 'activity.freezed.dart';
 part 'activity.g.dart';
 
@@ -7,12 +9,21 @@ part 'activity.g.dart';
 abstract class Activity with _$Activity {
   const factory Activity({
     required int activityId,
-    required String date,
-    required String startTime,
-    required String endTime,
+    @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required DateTime date,
+    @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)
+    required TimeValue startTime,
+    @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)
+    required TimeValue endTime,
     @Default(false) bool isCompleted,
     int? pictogramId,
   }) = _Activity;
 
-  factory Activity.fromJson(Map<String, dynamic> json) => _$ActivityFromJson(json);
+  factory Activity.fromJson(Map<String, dynamic> json) =>
+      _$ActivityFromJson(json);
 }
+
+TimeValue _timeFromJson(String s) => parseTimeValue(s) ?? (hour: 0, minute: 0);
+String _timeToJson(TimeValue t) => formatTimeValueForApi(t);
+
+DateTime _dateFromJson(String s) => DateTime.parse(s);
+String _dateToJson(DateTime d) => GirafDateUtils.formatQueryDate(d);

--- a/frontend/lib/shared/models/activity.dart
+++ b/frontend/lib/shared/models/activity.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:logging/logging.dart';
 
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
@@ -22,7 +23,15 @@ abstract class Activity with _$Activity {
       _$ActivityFromJson(json);
 }
 
-TimeValue _timeFromJson(String s) => parseTimeValue(s) ?? (hour: 0, minute: 0);
+final _log = Logger('Activity');
+
+TimeValue _timeFromJson(String s) {
+  final parsed = parseTimeValue(s);
+  if (parsed == null) {
+    _log.warning('Unparseable time value: "$s", defaulting to 00:00');
+  }
+  return parsed ?? (hour: 0, minute: 0);
+}
 String _timeToJson(TimeValue t) => formatTimeValueForApi(t);
 
 DateTime _dateFromJson(String s) => DateTime.parse(s);

--- a/frontend/lib/shared/models/activity.freezed.dart
+++ b/frontend/lib/shared/models/activity.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Activity {
 
- int get activityId; String get date; String get startTime; String get endTime; bool get isCompleted; int? get pictogramId;
+ int get activityId;@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime get date;@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue get startTime;@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue get endTime; bool get isCompleted; int? get pictogramId;
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $ActivityCopyWith<$Res>  {
   factory $ActivityCopyWith(Activity value, $Res Function(Activity) _then) = _$ActivityCopyWithImpl;
 @useResult
 $Res call({
- int activityId, String date, String startTime, String endTime, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue startTime,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue endTime, bool isCompleted, int? pictogramId
 });
 
 
@@ -69,9 +69,9 @@ class _$ActivityCopyWithImpl<$Res>
   return _then(_self.copyWith(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
-as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as String,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as String,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as DateTime,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as TimeValue,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as TimeValue,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
 as int?,
   ));
@@ -158,7 +158,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId,  String date,  String startTime,  String endTime,  bool isCompleted,  int? pictogramId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
 return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
@@ -179,7 +179,7 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId,  String date,  String startTime,  String endTime,  bool isCompleted,  int? pictogramId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)  $default,) {final _that = this;
 switch (_that) {
 case _Activity():
 return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
@@ -199,7 +199,7 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId,  String date,  String startTime,  String endTime,  bool isCompleted,  int? pictogramId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)?  $default,) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
 return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
@@ -214,13 +214,13 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 @JsonSerializable()
 
 class _Activity implements Activity {
-  const _Activity({required this.activityId, required this.date, required this.startTime, required this.endTime, this.isCompleted = false, this.pictogramId});
+  const _Activity({required this.activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required this.date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) required this.startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) required this.endTime, this.isCompleted = false, this.pictogramId});
   factory _Activity.fromJson(Map<String, dynamic> json) => _$ActivityFromJson(json);
 
 @override final  int activityId;
-@override final  String date;
-@override final  String startTime;
-@override final  String endTime;
+@override@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) final  DateTime date;
+@override@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) final  TimeValue startTime;
+@override@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) final  TimeValue endTime;
 @override@JsonKey() final  bool isCompleted;
 @override final  int? pictogramId;
 
@@ -257,7 +257,7 @@ abstract mixin class _$ActivityCopyWith<$Res> implements $ActivityCopyWith<$Res>
   factory _$ActivityCopyWith(_Activity value, $Res Function(_Activity) _then) = __$ActivityCopyWithImpl;
 @override @useResult
 $Res call({
- int activityId, String date, String startTime, String endTime, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue startTime,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue endTime, bool isCompleted, int? pictogramId
 });
 
 
@@ -278,9 +278,9 @@ class __$ActivityCopyWithImpl<$Res>
   return _then(_Activity(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
-as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as String,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as String,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as DateTime,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as TimeValue,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as TimeValue,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
 as int?,
   ));

--- a/frontend/lib/shared/models/activity.g.dart
+++ b/frontend/lib/shared/models/activity.g.dart
@@ -8,18 +8,18 @@ part of 'activity.dart';
 
 _Activity _$ActivityFromJson(Map<String, dynamic> json) => _Activity(
   activityId: (json['activityId'] as num).toInt(),
-  date: json['date'] as String,
-  startTime: json['startTime'] as String,
-  endTime: json['endTime'] as String,
+  date: _dateFromJson(json['date'] as String),
+  startTime: _timeFromJson(json['startTime'] as String),
+  endTime: _timeFromJson(json['endTime'] as String),
   isCompleted: json['isCompleted'] as bool? ?? false,
   pictogramId: (json['pictogramId'] as num?)?.toInt(),
 );
 
 Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
   'activityId': instance.activityId,
-  'date': instance.date,
-  'startTime': instance.startTime,
-  'endTime': instance.endTime,
+  'date': _dateToJson(instance.date),
+  'startTime': _timeToJson(instance.startTime),
+  'endTime': _timeToJson(instance.endTime),
   'isCompleted': instance.isCompleted,
   'pictogramId': instance.pictogramId,
 };

--- a/frontend/lib/shared/utils/date_utils.dart
+++ b/frontend/lib/shared/utils/date_utils.dart
@@ -12,6 +12,7 @@ TimeValue? parseTimeValue(String time) {
   final hour = int.tryParse(parts[0]);
   final minute = int.tryParse(parts[1]);
   if (hour == null || minute == null) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
   return (hour: hour, minute: minute);
 }
 

--- a/frontend/lib/shared/utils/date_utils.dart
+++ b/frontend/lib/shared/utils/date_utils.dart
@@ -1,5 +1,27 @@
 import 'package:intl/intl.dart';
 
+/// Platform-agnostic time-of-day so domain/data layers avoid importing Flutter.
+typedef TimeValue = ({int hour, int minute});
+
+/// Parse a time string like "HH:mm" or "HH:mm:ss" into a [TimeValue].
+///
+/// Returns `null` if the string cannot be parsed.
+TimeValue? parseTimeValue(String time) {
+  final parts = time.split(':');
+  if (parts.length < 2) return null;
+  final hour = int.tryParse(parts[0]);
+  final minute = int.tryParse(parts[1]);
+  if (hour == null || minute == null) return null;
+  return (hour: hour, minute: minute);
+}
+
+/// Format a [TimeValue] as "HH:mm".
+String formatTimeValue(TimeValue t) =>
+    '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+
+/// Format a [TimeValue] as "HH:mm:ss" for API serialization.
+String formatTimeValueForApi(TimeValue t) => '${formatTimeValue(t)}:00';
+
 class GirafDateUtils {
   /// Returns the ISO 8601 week number for a given date.
   static int getWeekNumber(DateTime date) {

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -30,18 +30,18 @@ void main() {
 
   final testDate = DateTime(2026, 3, 22);
 
-  const testActivity = Activity(
+  final testActivity = Activity(
     activityId: 1,
-    date: '2026-03-22',
-    startTime: '08:00:00',
-    endTime: '09:00:00',
+    date: DateTime(2026, 3, 22),
+    startTime: const (hour: 8, minute: 0),
+    endTime: const (hour: 9, minute: 0),
   );
 
-  const testActivityWithPictogram = Activity(
+  final testActivityWithPictogram = Activity(
     activityId: 2,
-    date: '2026-03-15',
-    startTime: '10:30:00',
-    endTime: '11:45:00',
+    date: DateTime(2026, 3, 15),
+    startTime: const (hour: 10, minute: 30),
+    endTime: const (hour: 11, minute: 45),
     pictogramId: 42,
   );
 
@@ -342,7 +342,7 @@ void main() {
             isCitizen: any(named: 'isCitizen'),
             data: any(named: 'data'),
           ),
-        ).thenAnswer((_) async => const Right(testActivity));
+        ).thenAnswer((_) async => Right(testActivity));
       },
       build: buildCubit,
       act: (cubit) => cubit.save(),
@@ -392,7 +392,7 @@ void main() {
             any(),
             any(),
           ),
-        ).thenAnswer((_) async => const Right(testActivity));
+        ).thenAnswer((_) async => Right(testActivity));
       },
       build: () => buildCubit(existingActivity: testActivity),
       act: (cubit) => cubit.save(),

--- a/frontend/test/features/weekplan/activity_list_item_test.dart
+++ b/frontend/test/features/weekplan/activity_list_item_test.dart
@@ -7,15 +7,15 @@ import 'package:weekplanner/features/weekplan/presentation/widgets/activity_list
 import 'package:weekplanner/shared/models/activity.dart';
 
 void main() {
-  const testActivity = Activity(
+  final testActivity = Activity(
     activityId: 1,
-    date: '2026-03-22',
-    startTime: '08:00:00',
-    endTime: '09:00:00',
+    date: DateTime(2026, 3, 22),
+    startTime: const (hour: 8, minute: 0),
+    endTime: const (hour: 9, minute: 0),
   );
 
   Widget buildSubject({
-    Activity activity = testActivity,
+    Activity? activity,
     VoidCallback? onEdit,
     VoidCallback? onDelete,
     VoidCallback? onToggleStatus,
@@ -26,7 +26,7 @@ void main() {
       theme: girafTheme,
       home: Scaffold(
         body: ActivityListItem(
-          activity: activity,
+          activity: activity ?? testActivity,
           onEdit: onEdit ?? () {},
           onDelete: onDelete ?? () {},
           onToggleStatus: onToggleStatus ?? () {},
@@ -46,11 +46,11 @@ void main() {
 
     testWidgets('shows completed status icon when isCompleted is true',
         (tester) async {
-      const completedActivity = Activity(
+      final completedActivity = Activity(
         activityId: 1,
-        date: '2026-03-22',
-        startTime: '08:00:00',
-        endTime: '09:00:00',
+        date: DateTime(2026, 3, 22),
+        startTime: const (hour: 8, minute: 0),
+        endTime: const (hour: 9, minute: 0),
         isCompleted: true,
       );
 

--- a/frontend/test/features/weekplan/activity_repository_test.dart
+++ b/frontend/test/features/weekplan/activity_repository_test.dart
@@ -13,11 +13,11 @@ void main() {
   late MockActivityApiService mockApiService;
   late ActivityRepository repo;
 
-  const activity = Activity(
+  final activity = Activity(
     activityId: 1,
-    date: '2026-03-22',
-    startTime: '08:00:00',
-    endTime: '09:00:00',
+    date: DateTime(2026, 3, 22),
+    startTime: const (hour: 8, minute: 0),
+    endTime: const (hour: 9, minute: 0),
   );
 
   final date = DateTime(2026, 3, 22);

--- a/frontend/test/features/weekplan/weekplan_cubit_test.dart
+++ b/frontend/test/features/weekplan/weekplan_cubit_test.dart
@@ -24,18 +24,18 @@ void main() {
   final testDate = DateTime(2026, 3, 22);
   final testWeekDates = GirafDateUtils.getWeekDates(testDate);
 
-  const testActivity = Activity(
+  final testActivity = Activity(
     activityId: 1,
-    date: '2026-03-22',
-    startTime: '08:00:00',
-    endTime: '09:00:00',
+    date: DateTime(2026, 3, 22),
+    startTime: const (hour: 8, minute: 0),
+    endTime: const (hour: 9, minute: 0),
   );
 
-  const testActivityWithPictogram = Activity(
+  final testActivityWithPictogram = Activity(
     activityId: 2,
-    date: '2026-03-22',
-    startTime: '10:00:00',
-    endTime: '11:00:00',
+    date: DateTime(2026, 3, 22),
+    startTime: const (hour: 10, minute: 0),
+    endTime: const (hour: 11, minute: 0),
     pictogramId: 42,
   );
 
@@ -80,7 +80,7 @@ void main() {
             isCitizen: any(named: 'isCitizen'),
             date: any(named: 'date'),
           ),
-        ).thenAnswer((_) async => const Right([testActivity]));
+        ).thenAnswer((_) async => Right([testActivity]));
       },
       build: buildCubit,
       act: (cubit) => cubit.loadActivities(),
@@ -89,7 +89,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [testActivity],
+          activities: [testActivity],
         ),
       ],
     );
@@ -127,7 +127,7 @@ void main() {
             date: any(named: 'date'),
           ),
         ).thenAnswer(
-          (_) async => const Right([testActivityWithPictogram]),
+          (_) async => Right([testActivityWithPictogram]),
         );
         when(() => mockPictogramRepo.fetchPictogram(42))
             .thenAnswer((_) async => const Right(testPictogram));
@@ -139,12 +139,12 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [testActivityWithPictogram],
+          activities: [testActivityWithPictogram],
         ),
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [testActivityWithPictogram],
+          activities: [testActivityWithPictogram],
           pictogramMedia: const {
             42: (imageUrl: 'http://img', soundUrl: 'http://sound'),
           },
@@ -169,7 +169,7 @@ void main() {
             isCitizen: any(named: 'isCitizen'),
             date: any(named: 'date'),
           ),
-        ).thenAnswer((_) async => const Right([testActivity]));
+        ).thenAnswer((_) async => Right([testActivity]));
       },
       build: buildCubit,
       act: (cubit) => cubit.selectDate(newDate),
@@ -178,7 +178,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: newDate,
           weekDates: newWeekDates,
-          activities: const [testActivity],
+          activities: [testActivity],
         ),
       ],
     );
@@ -241,17 +241,17 @@ void main() {
   });
 
   group('deleteActivity', () {
-    const activityToDelete = Activity(
+    final activityToDelete = Activity(
       activityId: 99,
-      date: '2026-03-22',
-      startTime: '12:00:00',
-      endTime: '13:00:00',
+      date: DateTime(2026, 3, 22),
+      startTime: const (hour: 12, minute: 0),
+      endTime: const (hour: 13, minute: 0),
     );
 
     final loadedState = WeekplanLoaded(
       selectedDate: testDate,
       weekDates: testWeekDates,
-      activities: const [testActivity, activityToDelete],
+      activities: [testActivity, activityToDelete],
     );
 
     blocTest<WeekplanCubit, WeekplanState>(
@@ -267,7 +267,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [testActivity],
+          activities: [testActivity],
         ),
       ],
       verify: (_) {
@@ -288,7 +288,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [testActivity],
+          activities: [testActivity],
         ),
         loadedState,
       ],
@@ -304,26 +304,26 @@ void main() {
   });
 
   group('toggleActivityStatus', () {
-    const incompleteActivity = Activity(
+    final incompleteActivity = Activity(
       activityId: 5,
-      date: '2026-03-22',
-      startTime: '08:00:00',
-      endTime: '09:00:00',
+      date: DateTime(2026, 3, 22),
+      startTime: const (hour: 8, minute: 0),
+      endTime: const (hour: 9, minute: 0),
       isCompleted: false,
     );
 
-    const completedActivity = Activity(
+    final completedActivity = Activity(
       activityId: 5,
-      date: '2026-03-22',
-      startTime: '08:00:00',
-      endTime: '09:00:00',
+      date: DateTime(2026, 3, 22),
+      startTime: const (hour: 8, minute: 0),
+      endTime: const (hour: 9, minute: 0),
       isCompleted: true,
     );
 
     final loadedState = WeekplanLoaded(
       selectedDate: testDate,
       weekDates: testWeekDates,
-      activities: const [incompleteActivity],
+      activities: [incompleteActivity],
     );
 
     blocTest<WeekplanCubit, WeekplanState>(
@@ -343,7 +343,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [completedActivity],
+          activities: [completedActivity],
         ),
       ],
       verify: (_) {
@@ -370,7 +370,7 @@ void main() {
         WeekplanLoaded(
           selectedDate: testDate,
           weekDates: testWeekDates,
-          activities: const [completedActivity],
+          activities: [completedActivity],
         ),
         loadedState,
       ],

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -54,17 +54,17 @@ void main() {
     testWidgets('shows activity list items when loaded with activities',
         (tester) async {
       final activities = [
-        const Activity(
+        Activity(
           activityId: 1,
-          date: '2026-03-22',
-          startTime: '08:00:00',
-          endTime: '09:00:00',
+          date: DateTime(2026, 3, 22),
+          startTime: const (hour: 8, minute: 0),
+          endTime: const (hour: 9, minute: 0),
         ),
-        const Activity(
+        Activity(
           activityId: 2,
-          date: '2026-03-22',
-          startTime: '10:00:00',
-          endTime: '11:00:00',
+          date: DateTime(2026, 3, 22),
+          startTime: const (hour: 10, minute: 0),
+          endTime: const (hour: 11, minute: 0),
         ),
       ];
       when(() => mockCubit.state).thenReturn(WeekplanLoaded(

--- a/frontend/test/shared/utils/date_utils_test.dart
+++ b/frontend/test/shared/utils/date_utils_test.dart
@@ -98,4 +98,59 @@ void main() {
       });
     });
   });
+
+  group('parseTimeValue', () {
+    test('parses HH:mm format', () {
+      expect(parseTimeValue('08:30'), (hour: 8, minute: 30));
+    });
+
+    test('parses HH:mm:ss format (ignores seconds)', () {
+      expect(parseTimeValue('14:05:00'), (hour: 14, minute: 5));
+    });
+
+    test('returns null for empty string', () {
+      expect(parseTimeValue(''), isNull);
+    });
+
+    test('returns null for single segment', () {
+      expect(parseTimeValue('8'), isNull);
+    });
+
+    test('returns null for non-numeric parts', () {
+      expect(parseTimeValue('abc:def'), isNull);
+    });
+
+    test('returns null for out-of-range hour', () {
+      expect(parseTimeValue('25:00'), isNull);
+    });
+
+    test('returns null for out-of-range minute', () {
+      expect(parseTimeValue('12:60'), isNull);
+    });
+
+    test('returns null for negative values', () {
+      expect(parseTimeValue('-1:30'), isNull);
+    });
+
+    test('parses boundary values', () {
+      expect(parseTimeValue('00:00'), (hour: 0, minute: 0));
+      expect(parseTimeValue('23:59'), (hour: 23, minute: 59));
+    });
+  });
+
+  group('formatTimeValue', () {
+    test('formats as HH:mm with zero padding', () {
+      expect(formatTimeValue((hour: 8, minute: 5)), '08:05');
+    });
+
+    test('formats double-digit values', () {
+      expect(formatTimeValue((hour: 14, minute: 30)), '14:30');
+    });
+  });
+
+  group('formatTimeValueForApi', () {
+    test('appends :00 seconds', () {
+      expect(formatTimeValueForApi((hour: 8, minute: 30)), '08:30:00');
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Replace `String` fields (`startTime`, `endTime`, `date`) in the `Activity` model with `TimeValue` record typedef and `DateTime`
- Centralize time parsing/formatting in `date_utils.dart` with `parseTimeValue()`, `formatTimeValue()`, and `formatTimeValueForApi()` helpers
- Remove duplicate parsing logic: `ActivityFormCubit._parseTime()` and `ActivityListItem._formatTime()`
- JSON conversion handled at the model boundary via `@JsonKey` converters — no behavioral change to API payloads

Closes #32

## Test plan

- [x] `dart analyze` — zero warnings
- [x] `flutter test` — all 179 tests pass
- [ ] Manual: verify activity creation, editing, and display in weekplan views