### PR TITLE
refactor: split ActivityFormState into composed sub-states

### DIFF
--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -8,93 +8,166 @@ import 'package:weekplanner/shared/utils/date_utils.dart';
 /// Mode for how the user is adding a pictogram.
 enum PictogramMode { search, upload, generate }
 
-/// State managed by [ActivityFormCubit].
-sealed class ActivityFormState extends Equatable {
-  /// Start time of the activity.
+// ── Sub-state: Activity timing & identity ──────────────────
+
+/// Core activity form fields: when it happens and which activity is edited.
+class ActivityFormData with EquatableMixin {
   final TimeValue startTime;
-
-  /// End time of the activity.
   final TimeValue endTime;
-
-  /// Date of the activity.
   final DateTime date;
-
-  /// ID of the selected pictogram, if any.
-  final int? selectedPictogramId;
-
-  /// Full pictogram object, if selected.
-  final Pictogram? selectedPictogram;
-
-  /// The activity being edited, or null for new activities.
   final Activity? existingActivity;
 
-  /// Current pictogram selection mode.
-  final PictogramMode pictogramMode;
-
-  /// Name for a new pictogram being created.
-  final String pictogramName;
-
-  /// AI generation prompt for a new pictogram.
-  final String generatePrompt;
-
-  /// Selected image file for upload mode.
-  final PlatformFile? selectedImageFile;
-
-  /// Selected sound file for upload mode.
-  final PlatformFile? selectedSoundFile;
-
-  /// Whether to auto-generate sound for new pictograms.
-  final bool generateSound;
-
-  /// Whether a pictogram creation operation is in progress.
-  final bool isCreatingPictogram;
-
-  /// Current pictogram search results.
-  final List<Pictogram> searchResults;
-
-  /// Whether a pictogram search is in progress.
-  final bool isSearching;
-
-  const ActivityFormState({
+  const ActivityFormData({
     this.startTime = const (hour: 8, minute: 0),
     this.endTime = const (hour: 9, minute: 0),
     required this.date,
-    this.selectedPictogramId,
-    this.selectedPictogram,
     this.existingActivity,
-    this.pictogramMode = PictogramMode.search,
-    this.pictogramName = '',
-    this.generatePrompt = '',
-    this.selectedImageFile,
-    this.selectedSoundFile,
-    this.generateSound = true,
-    this.isCreatingPictogram = false,
-    this.searchResults = const [],
-    this.isSearching = false,
   });
 
-  /// Whether this is an edit (vs. create) operation.
   bool get isEditing => existingActivity != null;
+
+  ActivityFormData copyWith({
+    TimeValue? startTime,
+    TimeValue? endTime,
+    DateTime? date,
+    Activity? existingActivity,
+  }) {
+    return ActivityFormData(
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      date: date ?? this.date,
+      existingActivity: existingActivity ?? this.existingActivity,
+    );
+  }
+
+  @override
+  List<Object?> get props => [startTime, endTime, date, existingActivity];
+}
+
+// ── Sub-state: Pictogram selection ─────────────────────────
+
+/// Tracks the currently selected pictogram.
+class PictogramSelection with EquatableMixin {
+  final int? id;
+  final Pictogram? pictogram;
+
+  const PictogramSelection({this.id, this.pictogram});
+
+  PictogramSelection copyWith({int? id, Pictogram? pictogram}) {
+    return PictogramSelection(
+      id: id ?? this.id,
+      pictogram: pictogram ?? this.pictogram,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, pictogram];
+}
+
+// ── Sub-state: Pictogram creation (upload / generate) ──────
+
+/// Form state for creating a new pictogram via upload or AI generation.
+class PictogramCreation with EquatableMixin {
+  final PictogramMode mode;
+  final String name;
+  final String generatePrompt;
+  final PlatformFile? imageFile;
+  final PlatformFile? soundFile;
+  final bool generateSound;
+  final bool isCreating;
+
+  const PictogramCreation({
+    this.mode = PictogramMode.search,
+    this.name = '',
+    this.generatePrompt = '',
+    this.imageFile,
+    this.soundFile,
+    this.generateSound = true,
+    this.isCreating = false,
+  });
+
+  PictogramCreation copyWith({
+    PictogramMode? mode,
+    String? name,
+    String? generatePrompt,
+    PlatformFile? imageFile,
+    PlatformFile? soundFile,
+    bool? generateSound,
+    bool? isCreating,
+    bool clearImageFile = false,
+    bool clearSoundFile = false,
+  }) {
+    return PictogramCreation(
+      mode: mode ?? this.mode,
+      name: name ?? this.name,
+      generatePrompt: generatePrompt ?? this.generatePrompt,
+      imageFile: clearImageFile ? null : (imageFile ?? this.imageFile),
+      soundFile: clearSoundFile ? null : (soundFile ?? this.soundFile),
+      generateSound: generateSound ?? this.generateSound,
+      isCreating: isCreating ?? this.isCreating,
+    );
+  }
 
   @override
   List<Object?> get props => [
-        startTime,
-        endTime,
-        date,
-        selectedPictogramId,
-        selectedPictogram,
-        existingActivity,
-        pictogramMode,
-        pictogramName,
+        mode,
+        name,
         generatePrompt,
         // PlatformFile uses identity (reference) comparison — acceptable
-        selectedImageFile,
-        selectedSoundFile,
+        imageFile,
+        soundFile,
         generateSound,
-        isCreatingPictogram,
-        searchResults,
-        isSearching,
+        isCreating,
       ];
+}
+
+// ── Sub-state: Pictogram search ────────────────────────────
+
+/// Search results and loading state for the pictogram search tab.
+class PictogramSearch with EquatableMixin {
+  final List<Pictogram> results;
+  final bool isSearching;
+
+  const PictogramSearch({
+    this.results = const [],
+    this.isSearching = false,
+  });
+
+  PictogramSearch copyWith({
+    List<Pictogram>? results,
+    bool? isSearching,
+  }) {
+    return PictogramSearch(
+      results: results ?? this.results,
+      isSearching: isSearching ?? this.isSearching,
+    );
+  }
+
+  @override
+  List<Object?> get props => [results, isSearching];
+}
+
+// ── Composed state hierarchy ───────────────────────────────
+
+/// State managed by [ActivityFormCubit].
+sealed class ActivityFormState extends Equatable {
+  final ActivityFormData form;
+  final PictogramSelection selection;
+  final PictogramCreation creation;
+  final PictogramSearch search;
+
+  const ActivityFormState({
+    required this.form,
+    this.selection = const PictogramSelection(),
+    this.creation = const PictogramCreation(),
+    this.search = const PictogramSearch(),
+  });
+
+  /// Whether this is an edit (vs. create) operation.
+  bool get isEditing => form.isEditing;
+
+  @override
+  List<Object?> get props => [form, selection, creation, search];
 }
 
 /// Form is ready for user input.
@@ -104,21 +177,10 @@ final class ActivityFormReady extends ActivityFormState {
 
   const ActivityFormReady({
     this.error,
-    super.startTime,
-    super.endTime,
-    required super.date,
-    super.selectedPictogramId,
-    super.selectedPictogram,
-    super.existingActivity,
-    super.pictogramMode,
-    super.pictogramName,
-    super.generatePrompt,
-    super.selectedImageFile,
-    super.selectedSoundFile,
-    super.generateSound,
-    super.isCreatingPictogram,
-    super.searchResults,
-    super.isSearching,
+    required super.form,
+    super.selection,
+    super.creation,
+    super.search,
   });
 
   @override
@@ -128,41 +190,19 @@ final class ActivityFormReady extends ActivityFormState {
 /// The activity is being saved (create or update).
 final class ActivityFormSaving extends ActivityFormState {
   const ActivityFormSaving({
-    super.startTime,
-    super.endTime,
-    required super.date,
-    super.selectedPictogramId,
-    super.selectedPictogram,
-    super.existingActivity,
-    super.pictogramMode,
-    super.pictogramName,
-    super.generatePrompt,
-    super.selectedImageFile,
-    super.selectedSoundFile,
-    super.generateSound,
-    super.isCreatingPictogram,
-    super.searchResults,
-    super.isSearching,
+    required super.form,
+    super.selection,
+    super.creation,
+    super.search,
   });
 }
 
 /// The activity was saved successfully.
 final class ActivityFormSaved extends ActivityFormState {
   const ActivityFormSaved({
-    super.startTime,
-    super.endTime,
-    required super.date,
-    super.selectedPictogramId,
-    super.selectedPictogram,
-    super.existingActivity,
-    super.pictogramMode,
-    super.pictogramName,
-    super.generatePrompt,
-    super.selectedImageFile,
-    super.selectedSoundFile,
-    super.generateSound,
-    super.isCreatingPictogram,
-    super.searchResults,
-    super.isSearching,
+    required super.form,
+    super.selection,
+    super.creation,
+    super.search,
   });
 }

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -11,10 +11,17 @@ enum PictogramMode { search, upload, generate }
 // ── Sub-state: Activity timing & identity ──────────────────
 
 /// Core activity form fields: when it happens and which activity is edited.
-class ActivityFormData with EquatableMixin {
+final class ActivityFormData with EquatableMixin {
+  /// Start time of the activity.
   final TimeValue startTime;
+
+  /// End time of the activity.
   final TimeValue endTime;
+
+  /// Date of the activity.
   final DateTime date;
+
+  /// The activity being edited, or null for new activities.
   final Activity? existingActivity;
 
   const ActivityFormData({
@@ -24,6 +31,7 @@ class ActivityFormData with EquatableMixin {
     this.existingActivity,
   });
 
+  /// Whether this is an edit (vs. create) operation.
   bool get isEditing => existingActivity != null;
 
   ActivityFormData copyWith({
@@ -31,12 +39,15 @@ class ActivityFormData with EquatableMixin {
     TimeValue? endTime,
     DateTime? date,
     Activity? existingActivity,
+    bool clearExistingActivity = false,
   }) {
     return ActivityFormData(
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
       date: date ?? this.date,
-      existingActivity: existingActivity ?? this.existingActivity,
+      existingActivity: clearExistingActivity
+          ? null
+          : (existingActivity ?? this.existingActivity),
     );
   }
 
@@ -47,13 +58,21 @@ class ActivityFormData with EquatableMixin {
 // ── Sub-state: Pictogram selection ─────────────────────────
 
 /// Tracks the currently selected pictogram.
-class PictogramSelection with EquatableMixin {
+final class PictogramSelection with EquatableMixin {
+  /// ID of the selected pictogram, if any.
   final int? id;
+
+  /// Full pictogram object, if selected.
   final Pictogram? pictogram;
 
   const PictogramSelection({this.id, this.pictogram});
 
-  PictogramSelection copyWith({int? id, Pictogram? pictogram}) {
+  PictogramSelection copyWith({
+    int? id,
+    Pictogram? pictogram,
+    bool clearSelection = false,
+  }) {
+    if (clearSelection) return const PictogramSelection();
     return PictogramSelection(
       id: id ?? this.id,
       pictogram: pictogram ?? this.pictogram,
@@ -67,13 +86,26 @@ class PictogramSelection with EquatableMixin {
 // ── Sub-state: Pictogram creation (upload / generate) ──────
 
 /// Form state for creating a new pictogram via upload or AI generation.
-class PictogramCreation with EquatableMixin {
+final class PictogramCreation with EquatableMixin {
+  /// Current pictogram selection mode.
   final PictogramMode mode;
+
+  /// Name for a new pictogram being created.
   final String name;
+
+  /// AI generation prompt for a new pictogram.
   final String generatePrompt;
+
+  /// Selected image file for upload mode.
   final PlatformFile? imageFile;
+
+  /// Selected sound file for upload mode.
   final PlatformFile? soundFile;
+
+  /// Whether to auto-generate sound for new pictograms.
   final bool generateSound;
+
+  /// Whether a pictogram creation operation is in progress.
   final bool isCreating;
 
   const PictogramCreation({
@@ -113,7 +145,9 @@ class PictogramCreation with EquatableMixin {
         mode,
         name,
         generatePrompt,
-        // PlatformFile uses identity (reference) comparison — acceptable
+        // PlatformFile lacks value equality; identity comparison means
+        // Equatable treats a new copyWith as changed even with the same
+        // underlying file data — this is the desired conservative behavior.
         imageFile,
         soundFile,
         generateSound,
@@ -124,8 +158,11 @@ class PictogramCreation with EquatableMixin {
 // ── Sub-state: Pictogram search ────────────────────────────
 
 /// Search results and loading state for the pictogram search tab.
-class PictogramSearch with EquatableMixin {
+final class PictogramSearch with EquatableMixin {
+  /// Current pictogram search results.
   final List<Pictogram> results;
+
+  /// Whether a pictogram search is in progress.
   final bool isSearching;
 
   const PictogramSearch({
@@ -151,9 +188,16 @@ class PictogramSearch with EquatableMixin {
 
 /// State managed by [ActivityFormCubit].
 sealed class ActivityFormState extends Equatable {
+  /// Core activity form data (timing, date, identity).
   final ActivityFormData form;
+
+  /// Currently selected pictogram.
   final PictogramSelection selection;
+
+  /// Pictogram creation form state (upload/generate).
   final PictogramCreation creation;
+
+  /// Pictogram search state.
   final PictogramSearch search;
 
   const ActivityFormState({

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -39,51 +39,63 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
   })  : _activityRepository = activityRepository,
         _pictogramRepository = pictogramRepository,
         super(ActivityFormReady(
-          date: existingActivity?.date ?? initialDate,
-          startTime: existingActivity?.startTime ?? const (hour: 8, minute: 0),
-          endTime: existingActivity?.endTime ?? const (hour: 9, minute: 0),
-          selectedPictogramId: existingActivity?.pictogramId,
-          existingActivity: existingActivity,
+          form: ActivityFormData(
+            date: existingActivity?.date ?? initialDate,
+            startTime:
+                existingActivity?.startTime ?? const (hour: 8, minute: 0),
+            endTime: existingActivity?.endTime ?? const (hour: 9, minute: 0),
+            existingActivity: existingActivity,
+          ),
+          selection: PictogramSelection(
+            id: existingActivity?.pictogramId,
+          ),
         ));
 
   // ── Form field setters ────────────────────────────────────
 
   void setStartTime(TimeValue time) {
-    _emitReady(startTime: time);
+    _emitReady(form: state.form.copyWith(startTime: time));
   }
 
   void setEndTime(TimeValue time) {
-    _emitReady(endTime: time);
+    _emitReady(form: state.form.copyWith(endTime: time));
   }
 
   void setPictogramMode(PictogramMode mode) {
-    _emitReady(pictogramMode: mode);
+    _emitReady(creation: state.creation.copyWith(mode: mode));
   }
 
   void setPictogramName(String name) {
-    _emitReady(pictogramName: name);
+    _emitReady(creation: state.creation.copyWith(name: name));
   }
 
   void setGeneratePrompt(String prompt) {
-    _emitReady(generatePrompt: prompt);
+    _emitReady(creation: state.creation.copyWith(generatePrompt: prompt));
   }
 
   void setSelectedImageFile(PlatformFile? file) {
-    _emitReady(selectedImageFile: file);
+    if (file == null) {
+      _emitReady(creation: state.creation.copyWith(clearImageFile: true));
+    } else {
+      _emitReady(creation: state.creation.copyWith(imageFile: file));
+    }
   }
 
   void setSelectedSoundFile(PlatformFile? file) {
-    _emitReady(selectedSoundFile: file);
+    if (file == null) {
+      _emitReady(creation: state.creation.copyWith(clearSoundFile: true));
+    } else {
+      _emitReady(creation: state.creation.copyWith(soundFile: file));
+    }
   }
 
   void setGenerateSound(bool value) {
-    _emitReady(generateSound: value);
+    _emitReady(creation: state.creation.copyWith(generateSound: value));
   }
 
   void selectPictogram(Pictogram pictogram) {
     _emitReady(
-      selectedPictogramId: pictogram.id,
-      selectedPictogram: pictogram,
+      selection: PictogramSelection(id: pictogram.id, pictogram: pictogram),
     );
   }
 
@@ -99,15 +111,17 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Execute a pictogram search immediately.
   Future<void> searchPictograms(String query) async {
-    _emitReady(isSearching: true);
+    _emitReady(search: state.search.copyWith(isSearching: true));
 
     final result = await _pictogramRepository.searchPictograms(query);
     switch (result) {
       case Left(:final value):
         _log.warning('Pictogram search failed: ${value.message}');
-        _emitReady(isSearching: false);
+        _emitReady(search: state.search.copyWith(isSearching: false));
       case Right(:final value):
-        _emitReady(searchResults: value, isSearching: false);
+        _emitReady(
+          search: PictogramSearch(results: value, isSearching: false),
+        );
     }
   }
 
@@ -115,30 +129,32 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Upload a local image as a new pictogram and select it.
   Future<bool> uploadPictogramFromFile() async {
-    if (state.selectedImageFile == null || state.pictogramName.isEmpty) {
+    if (state.creation.imageFile == null || state.creation.name.isEmpty) {
       _emitReady(error: 'Angiv navn og vælg et billede');
       return false;
     }
 
-    _emitReady(isCreatingPictogram: true, error: null);
+    _emitReady(creation: state.creation.copyWith(isCreating: true));
 
     final result = await _pictogramRepository.uploadPictogram(
-      name: state.pictogramName,
-      imageFile: state.selectedImageFile!,
-      soundFile: state.selectedSoundFile,
+      name: state.creation.name,
+      imageFile: state.creation.imageFile!,
+      soundFile: state.creation.soundFile,
       organizationId: organizationId,
-      generateSound: state.generateSound,
+      generateSound: state.creation.generateSound,
     );
 
     switch (result) {
       case Left(:final value):
-        _emitReady(isCreatingPictogram: false, error: value.message);
+        _emitReady(
+          creation: state.creation.copyWith(isCreating: false),
+          error: value.message,
+        );
         return false;
       case Right(:final value):
         _emitReady(
-          isCreatingPictogram: false,
-          selectedPictogramId: value.id,
-          selectedPictogram: value,
+          creation: state.creation.copyWith(isCreating: false),
+          selection: PictogramSelection(id: value.id, pictogram: value),
         );
         return true;
     }
@@ -146,31 +162,34 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Create a pictogram via AI generation and select it.
   Future<bool> generatePictogram() async {
-    final prompt =
-        state.generatePrompt.isNotEmpty ? state.generatePrompt : state.pictogramName;
+    final prompt = state.creation.generatePrompt.isNotEmpty
+        ? state.creation.generatePrompt
+        : state.creation.name;
     if (prompt.isEmpty) {
       _emitReady(error: 'Angiv et navn eller en beskrivelse');
       return false;
     }
 
-    _emitReady(isCreatingPictogram: true, error: null);
+    _emitReady(creation: state.creation.copyWith(isCreating: true));
 
     final result = await _pictogramRepository.createPictogram(
       name: prompt,
       organizationId: organizationId,
       generateImage: true,
-      generateSound: state.generateSound,
+      generateSound: state.creation.generateSound,
     );
 
     switch (result) {
       case Left(:final value):
-        _emitReady(isCreatingPictogram: false, error: value.message);
+        _emitReady(
+          creation: state.creation.copyWith(isCreating: false),
+          error: value.message,
+        );
         return false;
       case Right(:final value):
         _emitReady(
-          isCreatingPictogram: false,
-          selectedPictogramId: value.id,
-          selectedPictogram: value,
+          creation: state.creation.copyWith(isCreating: false),
+          selection: PictogramSelection(id: value.id, pictogram: value),
         );
         return true;
     }
@@ -180,8 +199,10 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Validate the form and return an error message, or null if valid.
   String? validate() {
-    final startMinutes = state.startTime.hour * 60 + state.startTime.minute;
-    final endMinutes = state.endTime.hour * 60 + state.endTime.minute;
+    final startMinutes =
+        state.form.startTime.hour * 60 + state.form.startTime.minute;
+    final endMinutes =
+        state.form.endTime.hour * 60 + state.form.endTime.minute;
     if (endMinutes <= startMinutes) {
       return 'Sluttid skal være efter starttid';
     }
@@ -198,34 +219,23 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
     final s = state;
     emit(ActivityFormSaving(
-      startTime: s.startTime,
-      endTime: s.endTime,
-      date: s.date,
-      selectedPictogramId: s.selectedPictogramId,
-      selectedPictogram: s.selectedPictogram,
-      existingActivity: s.existingActivity,
-      pictogramMode: s.pictogramMode,
-      pictogramName: s.pictogramName,
-      generatePrompt: s.generatePrompt,
-      selectedImageFile: s.selectedImageFile,
-      selectedSoundFile: s.selectedSoundFile,
-      generateSound: s.generateSound,
-      isCreatingPictogram: s.isCreatingPictogram,
-      searchResults: s.searchResults,
-      isSearching: s.isSearching,
+      form: s.form,
+      selection: s.selection,
+      creation: s.creation,
+      search: s.search,
     ));
 
     final data = {
-      'date': GirafDateUtils.formatQueryDate(s.date),
-      'startTime': formatTimeValueForApi(s.startTime),
-      'endTime': formatTimeValueForApi(s.endTime),
-      if (s.selectedPictogramId != null) 'pictogramId': s.selectedPictogramId,
+      'date': GirafDateUtils.formatQueryDate(s.form.date),
+      'startTime': formatTimeValueForApi(s.form.startTime),
+      'endTime': formatTimeValueForApi(s.form.endTime),
+      if (s.selection.id != null) 'pictogramId': s.selection.id,
     };
 
     final Either<ActivityFailure, Activity> result;
-    if (s.isEditing) {
+    if (s.form.isEditing) {
       result = await _activityRepository.updateActivity(
-          s.existingActivity!.activityId, data);
+          s.form.existingActivity!.activityId, data);
     } else {
       result = await _activityRepository.createActivity(
         id: subjectId,
@@ -240,20 +250,10 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         return false;
       case Right():
         emit(ActivityFormSaved(
-          startTime: s.startTime,
-          endTime: s.endTime,
-          date: s.date,
-          selectedPictogramId: s.selectedPictogramId,
-          selectedPictogram: s.selectedPictogram,
-          existingActivity: s.existingActivity,
-          pictogramMode: s.pictogramMode,
-          pictogramName: s.pictogramName,
-          generatePrompt: s.generatePrompt,
-          selectedImageFile: s.selectedImageFile,
-          selectedSoundFile: s.selectedSoundFile,
-          generateSound: s.generateSound,
-          searchResults: s.searchResults,
-          isSearching: s.isSearching,
+          form: s.form,
+          selection: s.selection,
+          creation: s.creation,
+          search: s.search,
         ));
         return true;
     }
@@ -261,49 +261,21 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   // ── Helpers ──────────────────────────────────────────────
 
-  /// Emit an [ActivityFormReady] state, carrying forward all fields
+  /// Emit an [ActivityFormReady] state, carrying forward all sub-states
   /// from the current state unless explicitly overridden.
-  ///
-  /// Note: nullable fields (selectedPictogramId, selectedPictogram,
-  /// selectedImageFile, selectedSoundFile) cannot be cleared back to null
-  /// through this helper — the `??` pattern preserves the old value when
-  /// null is passed. This is acceptable because the current UI does not
-  /// support deselecting these fields. If deselection is needed in the
-  /// future, use a sentinel wrapper or a dedicated clear method.
   void _emitReady({
     String? error,
-    TimeValue? startTime,
-    TimeValue? endTime,
-    int? selectedPictogramId,
-    Pictogram? selectedPictogram,
-    PictogramMode? pictogramMode,
-    String? pictogramName,
-    String? generatePrompt,
-    PlatformFile? selectedImageFile,
-    PlatformFile? selectedSoundFile,
-    bool? generateSound,
-    bool? isCreatingPictogram,
-    List<Pictogram>? searchResults,
-    bool? isSearching,
+    ActivityFormData? form,
+    PictogramSelection? selection,
+    PictogramCreation? creation,
+    PictogramSearch? search,
   }) {
-    final s = state;
     emit(ActivityFormReady(
       error: error,
-      startTime: startTime ?? s.startTime,
-      endTime: endTime ?? s.endTime,
-      date: s.date,
-      selectedPictogramId: selectedPictogramId ?? s.selectedPictogramId,
-      selectedPictogram: selectedPictogram ?? s.selectedPictogram,
-      existingActivity: s.existingActivity,
-      pictogramMode: pictogramMode ?? s.pictogramMode,
-      pictogramName: pictogramName ?? s.pictogramName,
-      generatePrompt: generatePrompt ?? s.generatePrompt,
-      selectedImageFile: selectedImageFile ?? s.selectedImageFile,
-      selectedSoundFile: selectedSoundFile ?? s.selectedSoundFile,
-      generateSound: generateSound ?? s.generateSound,
-      isCreatingPictogram: isCreatingPictogram ?? s.isCreatingPictogram,
-      searchResults: searchResults ?? s.searchResults,
-      isSearching: isSearching ?? s.isSearching,
+      form: form ?? state.form,
+      selection: selection ?? state.selection,
+      creation: creation ?? state.creation,
+      search: search ?? state.search,
     ));
   }
 

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -43,13 +43,13 @@ class ActivityFormView extends StatelessWidget {
                     Expanded(
                       child: _TimePicker(
                         label: 'Starttid',
-                        time: state.startTime,
+                        time: state.form.startTime,
                         onTap: () async {
                           final picked = await showTimePicker(
                             context: context,
                             initialTime: TimeOfDay(
-                              hour: state.startTime.hour,
-                              minute: state.startTime.minute,
+                              hour: state.form.startTime.hour,
+                              minute: state.form.startTime.minute,
                             ),
                           );
                           if (picked != null && context.mounted) {
@@ -64,13 +64,13 @@ class ActivityFormView extends StatelessWidget {
                     Expanded(
                       child: _TimePicker(
                         label: 'Sluttid',
-                        time: state.endTime,
+                        time: state.form.endTime,
                         onTap: () async {
                           final picked = await showTimePicker(
                             context: context,
                             initialTime: TimeOfDay(
-                              hour: state.endTime.hour,
-                              minute: state.endTime.minute,
+                              hour: state.form.endTime.hour,
+                              minute: state.form.endTime.minute,
                             ),
                           );
                           if (picked != null && context.mounted) {

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -54,7 +54,7 @@ class _PictogramSelectorState extends State<PictogramSelector> {
                   icon: Icon(Icons.auto_awesome),
                 ),
               ],
-              selected: {state.pictogramMode},
+              selected: {state.creation.mode},
               onSelectionChanged: (modes) =>
                   cubit.setPictogramMode(modes.first),
             ),
@@ -62,7 +62,7 @@ class _PictogramSelectorState extends State<PictogramSelector> {
 
             // Content per mode
             _PictogramModeContent(
-              mode: state.pictogramMode,
+              mode: state.creation.mode,
               state: state,
               cubit: cubit,
               searchController: _searchController,
@@ -71,10 +71,10 @@ class _PictogramSelectorState extends State<PictogramSelector> {
             ),
 
             // Selected pictogram preview
-            if (state.selectedPictogram != null) ...[
+            if (state.selection.pictogram != null) ...[
               const SizedBox(height: 12),
               // Guarded by != null check above.
-              _SelectedPictogramPreview(pictogram: state.selectedPictogram!),
+              _SelectedPictogramPreview(pictogram: state.selection.pictogram!),
             ],
           ],
         );
@@ -109,17 +109,17 @@ class _PictogramModeContent extends StatelessWidget {
       PictogramMode.search => _SearchTab(
           controller: searchController,
           onSearchChanged: cubit.onSearchQueryChanged,
-          pictograms: state.searchResults,
-          isLoading: state.isSearching,
-          selectedId: state.selectedPictogramId,
+          pictograms: state.search.results,
+          isLoading: state.search.isSearching,
+          selectedId: state.selection.id,
           onSelect: cubit.selectPictogram,
         ),
       PictogramMode.upload => _UploadTab(
           nameController: nameController,
-          selectedImageFile: state.selectedImageFile,
-          selectedSoundFile: state.selectedSoundFile,
-          generateSound: state.generateSound,
-          isCreatingPictogram: state.isCreatingPictogram,
+          selectedImageFile: state.creation.imageFile,
+          selectedSoundFile: state.creation.soundFile,
+          generateSound: state.creation.generateSound,
+          isCreatingPictogram: state.creation.isCreating,
           onNameChanged: cubit.setPictogramName,
           onImageFilePicked: cubit.setSelectedImageFile,
           onSoundFilePicked: cubit.setSelectedSoundFile,
@@ -129,8 +129,8 @@ class _PictogramModeContent extends StatelessWidget {
       PictogramMode.generate => _GenerateTab(
           nameController: nameController,
           promptController: promptController,
-          generateSound: state.generateSound,
-          isCreatingPictogram: state.isCreatingPictogram,
+          generateSound: state.creation.generateSound,
+          isCreatingPictogram: state.creation.isCreating,
           onNameChanged: cubit.setPictogramName,
           onPromptChanged: cubit.setGeneratePrompt,
           onGenerateSoundChanged: cubit.setGenerateSound,

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -83,7 +83,7 @@ class _PictogramSelectorState extends State<PictogramSelector> {
   }
 }
 
-// ── Search tab (existing behavior) ──────────────────────────
+// ── Mode content router ───────────────────────────────────────
 
 /// Renders the appropriate tab content based on the selected [PictogramMode].
 class _PictogramModeContent extends StatelessWidget {

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -66,21 +66,21 @@ void main() {
     test('is ActivityFormReady with default times for new activity', () {
       final cubit = buildCubit();
       expect(cubit.state, isA<ActivityFormReady>());
-      expect(cubit.state.startTime, const (hour: 8, minute: 0));
-      expect(cubit.state.endTime, const (hour: 9, minute: 0));
-      expect(cubit.state.date, testDate);
-      expect(cubit.state.existingActivity, isNull);
+      expect(cubit.state.form.startTime, const (hour: 8, minute: 0));
+      expect(cubit.state.form.endTime, const (hour: 9, minute: 0));
+      expect(cubit.state.form.date, testDate);
+      expect(cubit.state.form.existingActivity, isNull);
       cubit.close();
     });
 
     test('parses existing activity times and date in edit mode', () {
       final cubit = buildCubit(existingActivity: testActivityWithPictogram);
       expect(cubit.state, isA<ActivityFormReady>());
-      expect(cubit.state.startTime, const (hour: 10, minute: 30));
-      expect(cubit.state.endTime, const (hour: 11, minute: 45));
-      expect(cubit.state.date, DateTime(2026, 3, 15));
-      expect(cubit.state.selectedPictogramId, 42);
-      expect(cubit.state.existingActivity, testActivityWithPictogram);
+      expect(cubit.state.form.startTime, const (hour: 10, minute: 30));
+      expect(cubit.state.form.endTime, const (hour: 11, minute: 45));
+      expect(cubit.state.form.date, DateTime(2026, 3, 15));
+      expect(cubit.state.selection.id, 42);
+      expect(cubit.state.form.existingActivity, testActivityWithPictogram);
       cubit.close();
     });
   });
@@ -92,7 +92,7 @@ void main() {
       act: (cubit) => cubit.setStartTime(const (hour: 10, minute: 30)),
       expect: () => [
         isA<ActivityFormReady>().having(
-          (s) => s.startTime,
+          (s) => s.form.startTime,
           'startTime',
           const (hour: 10, minute: 30),
         ),
@@ -107,7 +107,7 @@ void main() {
       act: (cubit) => cubit.setEndTime(const (hour: 11, minute: 0)),
       expect: () => [
         isA<ActivityFormReady>().having(
-          (s) => s.endTime,
+          (s) => s.form.endTime,
           'endTime',
           const (hour: 11, minute: 0),
         ),
@@ -122,7 +122,7 @@ void main() {
       act: (cubit) => cubit.setPictogramMode(PictogramMode.upload),
       expect: () => [
         isA<ActivityFormReady>().having(
-          (s) => s.pictogramMode,
+          (s) => s.creation.mode,
           'pictogramMode',
           PictogramMode.upload,
         ),
@@ -137,9 +137,9 @@ void main() {
       act: (cubit) => cubit.selectPictogram(testPictogram),
       expect: () => [
         isA<ActivityFormReady>()
-            .having((s) => s.selectedPictogramId, 'selectedPictogramId', 1)
+            .having((s) => s.selection.id, 'selectedPictogramId', 1)
             .having(
-              (s) => s.selectedPictogram,
+              (s) => s.selection.pictogram,
               'selectedPictogram',
               testPictogram,
             ),
@@ -158,14 +158,14 @@ void main() {
       act: (cubit) => cubit.searchPictograms('test'),
       expect: () => [
         isA<ActivityFormReady>().having(
-          (s) => s.isSearching,
+          (s) => s.search.isSearching,
           'isSearching',
           true,
         ),
         isA<ActivityFormReady>()
-            .having((s) => s.isSearching, 'isSearching', false)
+            .having((s) => s.search.isSearching, 'isSearching', false)
             .having(
-              (s) => s.searchResults,
+              (s) => s.search.results,
               'searchResults',
               const [testPictogram],
             ),
@@ -182,12 +182,12 @@ void main() {
       act: (cubit) => cubit.searchPictograms('test'),
       expect: () => [
         isA<ActivityFormReady>().having(
-          (s) => s.isSearching,
+          (s) => s.search.isSearching,
           'isSearching',
           true,
         ),
         isA<ActivityFormReady>().having(
-          (s) => s.isSearching,
+          (s) => s.search.isSearching,
           'isSearching',
           false,
         ),
@@ -226,8 +226,8 @@ void main() {
       final result = await cubit.uploadPictogramFromFile();
       expect(result, isTrue);
       expect(cubit.state, isA<ActivityFormReady>());
-      expect(cubit.state.selectedPictogramId, 1);
-      expect(cubit.state.selectedPictogram, testPictogram);
+      expect(cubit.state.selection.id, 1);
+      expect(cubit.state.selection.pictogram, testPictogram);
       cubit.close();
     });
 
@@ -280,8 +280,8 @@ void main() {
 
       final result = await cubit.generatePictogram();
       expect(result, isTrue);
-      expect(cubit.state.selectedPictogramId, 1);
-      expect(cubit.state.selectedPictogram, testPictogram);
+      expect(cubit.state.selection.id, 1);
+      expect(cubit.state.selection.pictogram, testPictogram);
       cubit.close();
     });
 
@@ -418,7 +418,7 @@ void main() {
       expect: () => [
         // setStartTime emits
         isA<ActivityFormReady>().having(
-          (s) => s.startTime,
+          (s) => s.form.startTime,
           'startTime',
           const (hour: 10, minute: 0),
         ),

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -38,7 +38,7 @@ void main() {
     testWidgets('shows time pickers and submit button in ready state',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
+        form: ActivityFormData(date: testDate),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -50,7 +50,7 @@ void main() {
 
     testWidgets('shows error text in ready state with error', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
+        form: ActivityFormData(date: testDate),
         error: 'Sluttid skal være efter starttid',
       ));
 
@@ -62,7 +62,7 @@ void main() {
     testWidgets('disables submit button and shows spinner in saving state',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormSaving(
-        date: testDate,
+        form: ActivityFormData(date: testDate),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -78,7 +78,7 @@ void main() {
 
     testWidgets('tapping submit calls save', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
+        form: ActivityFormData(date: testDate),
       ));
       when(() => mockCubit.save()).thenAnswer((_) async => true);
 

--- a/frontend/test/features/weekplan/pictogram_selector_test.dart
+++ b/frontend/test/features/weekplan/pictogram_selector_test.dart
@@ -17,6 +17,7 @@ void main() {
   late MockActivityFormCubit mockCubit;
 
   final testDate = DateTime(2026, 3, 22);
+  final defaultForm = ActivityFormData(date: testDate);
 
   setUp(() {
     mockCubit = MockActivityFormCubit();
@@ -37,7 +38,7 @@ void main() {
   group('PictogramSelector', () {
     testWidgets('renders 3 mode segments', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
+        form: defaultForm,
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -49,8 +50,8 @@ void main() {
 
     testWidgets('search mode shows search field', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        pictogramMode: PictogramMode.search,
+        form: defaultForm,
+        creation: const PictogramCreation(mode: PictogramMode.search),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -64,9 +65,9 @@ void main() {
     testWidgets('search mode shows loading indicator when searching',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        pictogramMode: PictogramMode.search,
-        isSearching: true,
+        form: defaultForm,
+        creation: const PictogramCreation(mode: PictogramMode.search),
+        search: const PictogramSearch(isSearching: true),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -78,9 +79,9 @@ void main() {
         (tester) async {
       const pictogram = Pictogram(id: 1, name: 'test');
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        pictogramMode: PictogramMode.search,
-        searchResults: [pictogram],
+        form: defaultForm,
+        creation: const PictogramCreation(mode: PictogramMode.search),
+        search: const PictogramSearch(results: [pictogram]),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -91,8 +92,8 @@ void main() {
 
     testWidgets('upload mode shows name field and image button', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        pictogramMode: PictogramMode.upload,
+        form: defaultForm,
+        creation: const PictogramCreation(mode: PictogramMode.upload),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -104,8 +105,8 @@ void main() {
     testWidgets('generate mode shows name field and prompt field',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        pictogramMode: PictogramMode.generate,
+        form: defaultForm,
+        creation: const PictogramCreation(mode: PictogramMode.generate),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -117,9 +118,8 @@ void main() {
         (tester) async {
       const pictogram = Pictogram(id: 1, name: 'Sol');
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
-        selectedPictogram: pictogram,
-        selectedPictogramId: 1,
+        form: defaultForm,
+        selection: const PictogramSelection(id: 1, pictogram: pictogram),
       ));
 
       await tester.pumpWidget(buildSubject());
@@ -131,7 +131,7 @@ void main() {
     testWidgets('shows no preview when no pictogram is selected',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
-        date: testDate,
+        form: defaultForm,
       ));
 
       await tester.pumpWidget(buildSubject());


### PR DESCRIPTION
## Summary

- Decompose the 16-field `ActivityFormState` into 4 focused sub-state objects:
  - `ActivityFormData` (4 fields) — timing & identity
  - `PictogramSelection` (2 fields) — chosen pictogram
  - `PictogramCreation` (7 fields) — upload/generate form state
  - `PictogramSearch` (2 fields) — search results & loading
- Each sub-state has `EquatableMixin`, `copyWith()`, `const` constructor, `final` fields
- Sealed hierarchy (Ready/Saving/Saved) preserved
- `_emitReady` simplified from 14 params to 4 sub-state objects
- `PictogramCreation.copyWith()` supports `clearImageFile`/`clearSoundFile` flags, solving the `??` nullable-field clearing limitation

Closes #26

## Test plan

- [x] `dart analyze` — zero warnings
- [x] `flutter test` — all 191 tests pass
- [ ] Manual: verify activity form, pictogram search/upload/generate flows