### PR TITLE
refactor: split CoreApiService into focused service classes

### DIFF
--- a/frontend/integration_test/app_test.dart
+++ b/frontend/integration_test/app_test.dart
@@ -23,14 +23,18 @@ import 'package:weekplanner/shared/models/organisation.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/organisation_api_service.dart';
+import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 import 'package:weekplanner/shared/services/token_manager.dart';
 
 import '../test/helpers/jwt_test_helper.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
-class _MockCoreApiService extends Mock implements CoreApiService {}
+class _MockOrganisationApiService extends Mock
+    implements OrganisationApiService {}
+
+class _MockPictogramApiService extends Mock implements PictogramApiService {}
 
 class _MockActivityApiService extends Mock implements ActivityApiService {}
 
@@ -40,13 +44,15 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   late _MockAuthService mockAuthService;
-  late _MockCoreApiService mockCoreApiService;
+  late _MockOrganisationApiService mockOrgApiService;
+  late _MockPictogramApiService mockPictogramApiService;
   late _MockActivityApiService mockActivityApiService;
   late _MockTokenManager mockTokenManager;
 
   setUp(() {
     mockAuthService = _MockAuthService();
-    mockCoreApiService = _MockCoreApiService();
+    mockOrgApiService = _MockOrganisationApiService();
+    mockPictogramApiService = _MockPictogramApiService();
     mockActivityApiService = _MockActivityApiService();
     mockTokenManager = _MockTokenManager();
 
@@ -61,11 +67,11 @@ void main() {
   Widget buildApp() {
     final authRepository = AuthRepositoryImpl(authService: mockAuthService);
     final organisationRepository =
-        OrganisationRepositoryImpl(coreApiService: mockCoreApiService);
+        OrganisationRepositoryImpl(apiService: mockOrgApiService);
     final activityRepository =
         ActivityRepositoryImpl(apiService: mockActivityApiService);
     final pictogramRepository =
-        PictogramRepositoryImpl(coreApiService: mockCoreApiService);
+        PictogramRepositoryImpl(apiService: mockPictogramApiService);
 
     final authCubit = AuthCubit(
       repository: authRepository,
@@ -86,7 +92,8 @@ void main() {
     return MultiProvider(
       providers: [
         Provider<AuthService>.value(value: mockAuthService),
-        Provider<CoreApiService>.value(value: mockCoreApiService),
+        Provider<OrganisationApiService>.value(value: mockOrgApiService),
+        Provider<PictogramApiService>.value(value: mockPictogramApiService),
         Provider<ActivityApiService>.value(value: mockActivityApiService),
         BlocProvider<AuthCubit>.value(value: authCubit),
         BlocProvider<LoginCubit>(
@@ -119,7 +126,7 @@ void main() {
     when(() => mockAuthService.logout()).thenAnswer((_) async {});
 
     // Stub organisations
-    when(() => mockCoreApiService.fetchOrganisations()).thenAnswer(
+    when(() => mockOrgApiService.fetchOrganisations()).thenAnswer(
       (_) async => PaginatedResponse(
         items: [const Organisation(id: 1, name: 'Test Org')],
         count: 1,
@@ -127,7 +134,7 @@ void main() {
     );
 
     // Stub citizens + grades for org 1
-    when(() => mockCoreApiService.fetchCitizens(1)).thenAnswer(
+    when(() => mockOrgApiService.fetchCitizens(1)).thenAnswer(
       (_) async => PaginatedResponse(
         items: [
           const Citizen(id: 10, firstName: 'Anders', lastName: 'Hansen'),
@@ -135,7 +142,7 @@ void main() {
         count: 1,
       ),
     );
-    when(() => mockCoreApiService.fetchGrades(1)).thenAnswer(
+    when(() => mockOrgApiService.fetchGrades(1)).thenAnswer(
       (_) async => PaginatedResponse<Grade>(items: [], count: 0),
     );
 

--- a/frontend/lib/features/organisation_picker/data/repositories/organisation_repository.dart
+++ b/frontend/lib/features/organisation_picker/data/repositories/organisation_repository.dart
@@ -6,7 +6,7 @@ import 'package:weekplanner/features/organisation_picker/domain/repositories/org
 import 'package:weekplanner/shared/models/citizen.dart';
 import 'package:weekplanner/shared/models/grade.dart';
 import 'package:weekplanner/shared/models/organisation.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/organisation_api_service.dart';
 
 final _log = Logger('OrganisationRepository');
 
@@ -15,16 +15,16 @@ final _log = Logger('OrganisationRepository');
 /// All methods return [Either] to communicate success or typed failure.
 /// No state management — that responsibility belongs to the ViewModel/Cubit.
 class OrganisationRepositoryImpl implements OrganisationRepository {
-  final CoreApiService _coreApiService;
+  final OrganisationApiService _apiService;
 
-  OrganisationRepositoryImpl({required CoreApiService coreApiService})
-      : _coreApiService = coreApiService;
+  OrganisationRepositoryImpl({required OrganisationApiService apiService})
+      : _apiService = apiService;
 
   @override
   Future<Either<OrganisationFailure, List<Organisation>>>
       fetchOrganisations() async {
     try {
-      final response = await _coreApiService.fetchOrganisations();
+      final response = await _apiService.fetchOrganisations();
       return Right(response.items);
     } catch (e, stackTrace) {
       _log.severe('Failed to fetch organisations', e, stackTrace);
@@ -38,8 +38,8 @@ class OrganisationRepositoryImpl implements OrganisationRepository {
           ({List<Citizen> citizens, List<Grade> grades})>>
       fetchCitizensAndGrades(int orgId) async {
     try {
-      final citizenResponse = await _coreApiService.fetchCitizens(orgId);
-      final gradeResponse = await _coreApiService.fetchGrades(orgId);
+      final citizenResponse = await _apiService.fetchCitizens(orgId);
+      final gradeResponse = await _apiService.fetchGrades(orgId);
       return Right(
         (citizens: citizenResponse.items, grades: gradeResponse.items),
       );

--- a/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
@@ -6,7 +6,7 @@ import 'package:logging/logging.dart';
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 
 final _log = Logger('PictogramRepository');
 
@@ -15,17 +15,17 @@ final _log = Logger('PictogramRepository');
 /// All methods return [Either] to communicate success or typed failure.
 /// No state management — that responsibility belongs to the cubit.
 class PictogramRepositoryImpl implements PictogramRepository {
-  final CoreApiService _coreApiService;
+  final PictogramApiService _apiService;
 
-  PictogramRepositoryImpl({required CoreApiService coreApiService})
-      : _coreApiService = coreApiService;
+  PictogramRepositoryImpl({required PictogramApiService apiService})
+      : _apiService = apiService;
 
   @override
   Future<Either<PictogramFailure, List<Pictogram>>> searchPictograms(
     String query,
   ) async {
     try {
-      final response = await _coreApiService.searchPictograms(query: query);
+      final response = await _apiService.searchPictograms(query: query);
       return Right(response.items);
     } catch (e, stackTrace) {
       _log.severe('Failed to search pictograms', e, stackTrace);
@@ -36,7 +36,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
   @override
   Future<Either<PictogramFailure, Pictogram>> fetchPictogram(int id) async {
     try {
-      final pictogram = await _coreApiService.fetchPictogram(id);
+      final pictogram = await _apiService.fetchPictogram(id);
       return Right(pictogram);
     } catch (e, stackTrace) {
       _log.severe('Failed to fetch pictogram $id', e, stackTrace);
@@ -53,7 +53,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
     bool generateSound = true,
   }) async {
     try {
-      final pictogram = await _coreApiService.createPictogram(
+      final pictogram = await _apiService.createPictogram(
         name: name,
         imageUrl: imageUrl,
         organizationId: organizationId,
@@ -76,7 +76,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
     bool generateSound = true,
   }) async {
     try {
-      final pictogram = await _coreApiService.uploadPictogram(
+      final pictogram = await _apiService.uploadPictogram(
         name: name,
         imageFile: _toMultipartFile(imageFile),
         soundFile: soundFile != null ? _toMultipartFile(soundFile) : null,

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -19,8 +19,9 @@ import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repo
 import 'package:weekplanner/shared/interceptors/token_refresh_interceptor.dart';
 import 'package:weekplanner/shared/services/activity_api_service.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
 import 'package:weekplanner/shared/services/log_service.dart';
+import 'package:weekplanner/shared/services/organisation_api_service.dart';
+import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 import 'package:weekplanner/shared/services/token_manager.dart';
 
 Dio _createDio(String baseUrl) => Dio(BaseOptions(
@@ -41,26 +42,28 @@ void main() async {
   final authDio = _createDio(ApiConfig.coreBaseUrl);
   const storage = FlutterSecureStorage();
 
-  // Services
+  // Services — each focused on one giraf-core domain.
+  // OrganisationApiService and PictogramApiService share coreDio.
   final authService = AuthService(dio: authDio, storage: storage);
-  final coreApiService = CoreApiService(dio: coreDio);
+  final organisationApiService = OrganisationApiService(dio: coreDio);
+  final pictogramApiService = PictogramApiService(dio: coreDio);
   final activityApiService = ActivityApiService(dio: activityDio);
 
   // Repositories
   final authRepository = AuthRepositoryImpl(authService: authService);
   final organisationRepository = OrganisationRepositoryImpl(
-    coreApiService: coreApiService,
+    apiService: organisationApiService,
   );
   final activityRepository = ActivityRepositoryImpl(
     apiService: activityApiService,
   );
   final pictogramRepository = PictogramRepositoryImpl(
-    coreApiService: coreApiService,
+    apiService: pictogramApiService,
   );
 
   // Token distribution
   final tokenManager = TokenManager(
-    consumers: [coreApiService, activityApiService],
+    consumers: [organisationApiService, pictogramApiService, activityApiService],
   );
 
   // Auth cubit + router refresh adapter
@@ -102,7 +105,8 @@ void main() async {
       providers: [
         // Services
         Provider.value(value: authService),
-        Provider.value(value: coreApiService),
+        Provider.value(value: organisationApiService),
+        Provider.value(value: pictogramApiService),
         Provider.value(value: activityApiService),
 
         // Auth (BLoC)

--- a/frontend/lib/shared/services/organisation_api_service.dart
+++ b/frontend/lib/shared/services/organisation_api_service.dart
@@ -1,0 +1,52 @@
+import 'package:dio/dio.dart';
+
+import 'package:weekplanner/shared/models/citizen.dart';
+import 'package:weekplanner/shared/models/grade.dart';
+import 'package:weekplanner/shared/models/organisation.dart';
+import 'package:weekplanner/shared/models/paginated_response.dart';
+import 'package:weekplanner/shared/services/token_consumer.dart';
+
+class OrganisationApiService implements TokenConsumer {
+  final Dio _dio;
+
+  OrganisationApiService({required Dio dio}) : _dio = dio;
+
+  @override
+  void setAuthToken(String token) {
+    _dio.options.headers['Authorization'] = 'Bearer $token';
+  }
+
+  @override
+  void clearAuthToken() {
+    _dio.options.headers.remove('Authorization');
+  }
+
+  Future<PaginatedResponse<Organisation>> fetchOrganisations() async {
+    final response = await _dio.get('/api/v1/organizations');
+    return PaginatedResponse.fromJson(
+      response.data as Map<String, dynamic>,
+      Organisation.fromJson,
+    );
+  }
+
+  Future<Organisation> fetchOrganisation(int orgId) async {
+    final response = await _dio.get('/api/v1/organizations/$orgId');
+    return Organisation.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  Future<PaginatedResponse<Citizen>> fetchCitizens(int orgId) async {
+    final response = await _dio.get('/api/v1/organizations/$orgId/citizens');
+    return PaginatedResponse.fromJson(
+      response.data as Map<String, dynamic>,
+      Citizen.fromJson,
+    );
+  }
+
+  Future<PaginatedResponse<Grade>> fetchGrades(int orgId) async {
+    final response = await _dio.get('/api/v1/organizations/$orgId/grades');
+    return PaginatedResponse.fromJson(
+      response.data as Map<String, dynamic>,
+      Grade.fromJson,
+    );
+  }
+}

--- a/frontend/lib/shared/services/organisation_api_service.dart
+++ b/frontend/lib/shared/services/organisation_api_service.dart
@@ -6,6 +6,10 @@ import 'package:weekplanner/shared/models/organisation.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/services/token_consumer.dart';
 
+/// HTTP client for giraf-core organisation, citizen, and grade endpoints.
+///
+/// Shares a Dio instance with [PictogramApiService] — both receive the same
+/// `coreDio` from `main.dart`, so auth token updates apply to both.
 class OrganisationApiService implements TokenConsumer {
   final Dio _dio;
 
@@ -21,6 +25,7 @@ class OrganisationApiService implements TokenConsumer {
     _dio.options.headers.remove('Authorization');
   }
 
+  /// Fetch all organisations the current user belongs to.
   Future<PaginatedResponse<Organisation>> fetchOrganisations() async {
     final response = await _dio.get('/api/v1/organizations');
     return PaginatedResponse.fromJson(
@@ -29,11 +34,13 @@ class OrganisationApiService implements TokenConsumer {
     );
   }
 
+  /// Fetch a single organisation by ID.
   Future<Organisation> fetchOrganisation(int orgId) async {
     final response = await _dio.get('/api/v1/organizations/$orgId');
     return Organisation.fromJson(response.data as Map<String, dynamic>);
   }
 
+  /// Fetch citizens for a given organisation.
   Future<PaginatedResponse<Citizen>> fetchCitizens(int orgId) async {
     final response = await _dio.get('/api/v1/organizations/$orgId/citizens');
     return PaginatedResponse.fromJson(
@@ -42,6 +49,7 @@ class OrganisationApiService implements TokenConsumer {
     );
   }
 
+  /// Fetch grades for a given organisation.
   Future<PaginatedResponse<Grade>> fetchGrades(int orgId) async {
     final response = await _dio.get('/api/v1/organizations/$orgId/grades');
     return PaginatedResponse.fromJson(

--- a/frontend/lib/shared/services/pictogram_api_service.dart
+++ b/frontend/lib/shared/services/pictogram_api_service.dart
@@ -1,34 +1,14 @@
 import 'package:dio/dio.dart';
+
 import 'package:weekplanner/config/api_config.dart';
-import 'package:weekplanner/shared/models/citizen.dart';
-import 'package:weekplanner/shared/models/grade.dart';
-import 'package:weekplanner/shared/models/organisation.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/services/token_consumer.dart';
 
-class CoreApiService implements TokenConsumer {
+class PictogramApiService implements TokenConsumer {
   final Dio _dio;
 
-  CoreApiService({required Dio dio}) : _dio = dio;
-
-  /// Resolve media URLs on a [Pictogram] to absolute URLs.
-  ///
-  /// giraf-core may return:
-  /// - A relative path (`/media/pictograms/...`) for uploaded/generated files.
-  /// - An absolute URL (`https://...`) for externally-provided images.
-  /// - An empty string when no media is present (e.g. no sound).
-  Pictogram _resolvePictogramUrls(Pictogram p) => p.copyWith(
-        imageUrl: _resolveMediaUrl(p.imageUrl),
-        soundUrl: _resolveMediaUrl(p.soundUrl),
-      );
-
-  String? _resolveMediaUrl(String? url) {
-    if (url == null || url.isEmpty) return null;
-    final parsed = Uri.tryParse(url);
-    if (parsed != null && parsed.hasScheme) return url;
-    return '${ApiConfig.coreBaseUrl}$url';
-  }
+  PictogramApiService({required Dio dio}) : _dio = dio;
 
   @override
   void setAuthToken(String token) {
@@ -40,39 +20,6 @@ class CoreApiService implements TokenConsumer {
     _dio.options.headers.remove('Authorization');
   }
 
-  // Organizations
-  Future<PaginatedResponse<Organisation>> fetchOrganisations() async {
-    final response = await _dio.get('/api/v1/organizations');
-    return PaginatedResponse.fromJson(
-      response.data as Map<String, dynamic>,
-      Organisation.fromJson,
-    );
-  }
-
-  Future<Organisation> fetchOrganisation(int orgId) async {
-    final response = await _dio.get('/api/v1/organizations/$orgId');
-    return Organisation.fromJson(response.data as Map<String, dynamic>);
-  }
-
-  // Citizens
-  Future<PaginatedResponse<Citizen>> fetchCitizens(int orgId) async {
-    final response = await _dio.get('/api/v1/organizations/$orgId/citizens');
-    return PaginatedResponse.fromJson(
-      response.data as Map<String, dynamic>,
-      Citizen.fromJson,
-    );
-  }
-
-  // Grades
-  Future<PaginatedResponse<Grade>> fetchGrades(int orgId) async {
-    final response = await _dio.get('/api/v1/organizations/$orgId/grades');
-    return PaginatedResponse.fromJson(
-      response.data as Map<String, dynamic>,
-      Grade.fromJson,
-    );
-  }
-
-  // Pictograms — Read
   Future<PaginatedResponse<Pictogram>> searchPictograms({
     String? query,
     int limit = 20,
@@ -100,7 +47,6 @@ class CoreApiService implements TokenConsumer {
     );
   }
 
-  // Pictograms — Write
   Future<Pictogram> createPictogram({
     required String name,
     String? imageUrl,
@@ -134,7 +80,8 @@ class CoreApiService implements TokenConsumer {
       if (organizationId != null) 'organization_id': organizationId,
       'generate_sound': generateSound,
     });
-    final response = await _dio.post('/api/v1/pictograms/upload', data: formData);
+    final response =
+        await _dio.post('/api/v1/pictograms/upload', data: formData);
     return _resolvePictogramUrls(
       Pictogram.fromJson(response.data as Map<String, dynamic>),
     );
@@ -152,5 +99,23 @@ class CoreApiService implements TokenConsumer {
     return _resolvePictogramUrls(
       Pictogram.fromJson(response.data as Map<String, dynamic>),
     );
+  }
+
+  /// Resolve media URLs on a [Pictogram] to absolute URLs.
+  ///
+  /// giraf-core may return:
+  /// - A relative path (`/media/pictograms/...`) for uploaded/generated files.
+  /// - An absolute URL (`https://...`) for externally-provided images.
+  /// - An empty string when no media is present (e.g. no sound).
+  Pictogram _resolvePictogramUrls(Pictogram p) => p.copyWith(
+        imageUrl: _resolveMediaUrl(p.imageUrl),
+        soundUrl: _resolveMediaUrl(p.soundUrl),
+      );
+
+  String? _resolveMediaUrl(String? url) {
+    if (url == null || url.isEmpty) return null;
+    final parsed = Uri.tryParse(url);
+    if (parsed != null && parsed.hasScheme) return url;
+    return '${ApiConfig.coreBaseUrl}$url';
   }
 }

--- a/frontend/lib/shared/services/pictogram_api_service.dart
+++ b/frontend/lib/shared/services/pictogram_api_service.dart
@@ -5,6 +5,10 @@ import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/services/token_consumer.dart';
 
+/// HTTP client for giraf-core pictogram endpoints.
+///
+/// Shares a Dio instance with [OrganisationApiService] — both receive the same
+/// `coreDio` from `main.dart`, so auth token updates apply to both.
 class PictogramApiService implements TokenConsumer {
   final Dio _dio;
 
@@ -20,6 +24,7 @@ class PictogramApiService implements TokenConsumer {
     _dio.options.headers.remove('Authorization');
   }
 
+  /// Search pictograms by query string.
   Future<PaginatedResponse<Pictogram>> searchPictograms({
     String? query,
     int limit = 20,
@@ -40,6 +45,7 @@ class PictogramApiService implements TokenConsumer {
     );
   }
 
+  /// Fetch a single pictogram by ID.
   Future<Pictogram> fetchPictogram(int id) async {
     final response = await _dio.get('/api/v1/pictograms/$id');
     return _resolvePictogramUrls(
@@ -47,6 +53,7 @@ class PictogramApiService implements TokenConsumer {
     );
   }
 
+  /// Create a pictogram (optionally AI-generated).
   Future<Pictogram> createPictogram({
     required String name,
     String? imageUrl,
@@ -66,6 +73,7 @@ class PictogramApiService implements TokenConsumer {
     );
   }
 
+  /// Upload a pictogram with a local image file.
   Future<Pictogram> uploadPictogram({
     required String name,
     required MultipartFile imageFile,
@@ -87,6 +95,7 @@ class PictogramApiService implements TokenConsumer {
     );
   }
 
+  /// Upload a sound file for an existing pictogram.
   Future<Pictogram> uploadPictogramSound({
     required int pictogramId,
     required MultipartFile soundFile,

--- a/frontend/test/features/organisation_picker/organisation_repository_test.dart
+++ b/frontend/test/features/organisation_picker/organisation_repository_test.dart
@@ -8,12 +8,13 @@ import 'package:weekplanner/shared/models/citizen.dart';
 import 'package:weekplanner/shared/models/grade.dart';
 import 'package:weekplanner/shared/models/organisation.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/organisation_api_service.dart';
 
-class MockCoreApiService extends Mock implements CoreApiService {}
+class MockOrganisationApiService extends Mock
+    implements OrganisationApiService {}
 
 void main() {
-  late MockCoreApiService mockCore;
+  late MockOrganisationApiService mockCore;
   late OrganisationRepository repo;
 
   const org = Organisation(id: 1, name: 'Org A');
@@ -21,8 +22,8 @@ void main() {
   const grade = Grade(id: 20, name: 'Gruppe 1');
 
   setUp(() {
-    mockCore = MockCoreApiService();
-    repo = OrganisationRepositoryImpl(coreApiService: mockCore);
+    mockCore = MockOrganisationApiService();
+    repo = OrganisationRepositoryImpl(apiService: mockCore);
   });
 
   group('fetchOrganisations', () {

--- a/frontend/test/features/weekplan/pictogram_repository_test.dart
+++ b/frontend/test/features/weekplan/pictogram_repository_test.dart
@@ -10,16 +10,16 @@ import 'package:weekplanner/features/weekplan/data/repositories/pictogram_reposi
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
-import 'package:weekplanner/shared/services/core_api_service.dart';
+import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 
-class MockCoreApiService extends Mock implements CoreApiService {}
+class MockPictogramApiService extends Mock implements PictogramApiService {}
 
 class MockPlatformFile extends Mock implements PlatformFile {}
 
 class FakeMultipartFile extends Fake implements MultipartFile {}
 
 void main() {
-  late MockCoreApiService mockCore;
+  late MockPictogramApiService mockCore;
   late PictogramRepository repo;
 
   const testPictogram = Pictogram(id: 7, name: 'Bade');
@@ -29,8 +29,8 @@ void main() {
   });
 
   setUp(() {
-    mockCore = MockCoreApiService();
-    repo = PictogramRepositoryImpl(coreApiService: mockCore);
+    mockCore = MockPictogramApiService();
+    repo = PictogramRepositoryImpl(apiService: mockCore);
   });
 
   group('searchPictograms', () {


### PR DESCRIPTION
## Summary

- Replace monolithic `CoreApiService` (10 methods, 2 domains) with two focused services:
  - `OrganisationApiService` (4 methods: orgs, citizens, grades)
  - `PictogramApiService` (5 methods: search, fetch, create, upload + URL resolution)
- Both share the same `coreDio` instance — no Dio duplication
- Both implement `TokenConsumer` for auth token distribution
- Each repository now depends only on the service it actually needs
- `_resolveMediaUrl` stays in `PictogramApiService` where it belongs

Closes #30

## Test plan

- [x] `dart analyze` — zero warnings
- [x] `flutter test` — all 191 tests pass
- [ ] Manual: verify org picker and pictogram search/upload/generate flows