### PR TITLE
refactor: remove PlatformFile from domain layer

### DIFF
--- a/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
@@ -1,10 +1,10 @@
 import 'package:dio/dio.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 
@@ -70,8 +70,8 @@ class PictogramRepositoryImpl implements PictogramRepository {
   @override
   Future<Either<PictogramFailure, Pictogram>> uploadPictogram({
     required String name,
-    required PlatformFile imageFile,
-    PlatformFile? soundFile,
+    required FileData imageFile,
+    FileData? soundFile,
     int? organizationId,
     bool generateSound = true,
   }) async {
@@ -90,19 +90,20 @@ class PictogramRepositoryImpl implements PictogramRepository {
     }
   }
 
-  /// Convert a [PlatformFile] to a Dio [MultipartFile].
+  /// Convert a [FileData] record to a Dio [MultipartFile].
   ///
   /// Uses bytes on web (where path is unavailable) and path on native.
   /// Throws [StateError] if neither bytes nor path is available.
-  MultipartFile _toMultipartFile(PlatformFile file) {
-    if (file.bytes != null) {
-      return MultipartFile.fromBytes(file.bytes!, filename: file.name);
+  MultipartFile _toMultipartFile(FileData file) {
+    final (name: name, bytes: bytes, path: path, size: _) = file;
+    if (bytes != null) {
+      return MultipartFile.fromBytes(bytes, filename: name);
     }
-    if (file.path != null) {
-      return MultipartFile.fromFileSync(file.path!, filename: file.name);
+    if (path != null) {
+      return MultipartFile.fromFileSync(path, filename: name);
     }
     throw StateError(
-      'PlatformFile "${file.name}" has neither bytes nor path — '
+      'FileData "$name" has neither bytes nor path — '
       'cannot convert to MultipartFile',
     );
   }

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
-import 'package:file_picker/file_picker.dart';
 
 import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
@@ -97,10 +97,10 @@ final class PictogramCreation with EquatableMixin {
   final String generatePrompt;
 
   /// Selected image file for upload mode.
-  final PlatformFile? imageFile;
+  final FileData? imageFile;
 
   /// Selected sound file for upload mode.
-  final PlatformFile? soundFile;
+  final FileData? soundFile;
 
   /// Whether to auto-generate sound for new pictograms.
   final bool generateSound;
@@ -122,8 +122,8 @@ final class PictogramCreation with EquatableMixin {
     PictogramMode? mode,
     String? name,
     String? generatePrompt,
-    PlatformFile? imageFile,
-    PlatformFile? soundFile,
+    FileData? imageFile,
+    FileData? soundFile,
     bool? generateSound,
     bool? isCreating,
     bool clearImageFile = false,
@@ -145,9 +145,8 @@ final class PictogramCreation with EquatableMixin {
         mode,
         name,
         generatePrompt,
-        // PlatformFile lacks value equality; identity comparison means
-        // Equatable treats a new copyWith as changed even with the same
-        // underlying file data — this is the desired conservative behavior.
+        // FileData is a record — Dart records have structural equality,
+        // but the Uint8List bytes field uses identity comparison.
         imageFile,
         soundFile,
         generateSound,

--- a/frontend/lib/features/weekplan/domain/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/domain/repositories/pictogram_repository.dart
@@ -1,7 +1,7 @@
-import 'package:file_picker/file_picker.dart';
 import 'package:fpdart/fpdart.dart';
 
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 
 /// Contract for pictogram data operations.
@@ -26,8 +26,8 @@ abstract interface class PictogramRepository {
   /// Upload a pictogram with a local image file.
   Future<Either<PictogramFailure, Pictogram>> uploadPictogram({
     required String name,
-    required PlatformFile imageFile,
-    PlatformFile? soundFile,
+    required FileData imageFile,
+    FileData? soundFile,
     int? organizationId,
     bool generateSound = true,
   });

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/activity_failure.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/activity_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
@@ -73,7 +73,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     _emitReady(creation: state.creation.copyWith(generatePrompt: prompt));
   }
 
-  void setSelectedImageFile(PlatformFile? file) {
+  void setSelectedImageFile(FileData? file) {
     if (file == null) {
       _emitReady(creation: state.creation.copyWith(clearImageFile: true));
     } else {
@@ -81,7 +81,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     }
   }
 
-  void setSelectedSoundFile(PlatformFile? file) {
+  void setSelectedSoundFile(FileData? file) {
     if (file == null) {
       _emitReady(creation: state.creation.copyWith(clearSoundFile: true));
     } else {

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -5,11 +5,11 @@ import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/activity_failure.dart';
-import 'package:weekplanner/shared/models/file_data.dart';
+import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/activity_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
-import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
@@ -248,13 +249,13 @@ class _SearchTab extends StatelessWidget {
 
 class _UploadTab extends StatelessWidget {
   final TextEditingController nameController;
-  final PlatformFile? selectedImageFile;
-  final PlatformFile? selectedSoundFile;
+  final FileData? selectedImageFile;
+  final FileData? selectedSoundFile;
   final bool generateSound;
   final bool isCreatingPictogram;
   final ValueChanged<String> onNameChanged;
-  final ValueChanged<PlatformFile?> onImageFilePicked;
-  final ValueChanged<PlatformFile?> onSoundFilePicked;
+  final ValueChanged<FileData?> onImageFilePicked;
+  final ValueChanged<FileData?> onSoundFilePicked;
   final ValueChanged<bool> onGenerateSoundChanged;
   final Future<bool> Function() onUpload;
 
@@ -333,13 +334,21 @@ class _UploadTab extends StatelessWidget {
     );
   }
 
-  Future<PlatformFile?> _pickFile(List<String> extensions) async {
+  /// Pick a file and convert to domain-safe [FileData].
+  Future<FileData?> _pickFile(List<String> extensions) async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: extensions,
       withData: true,
     );
-    return result?.files.single;
+    final file = result?.files.single;
+    if (file == null) return null;
+    return (
+      name: file.name,
+      size: file.size,
+      bytes: file.bytes,
+      path: file.path,
+    );
   }
 }
 

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:weekplanner/config/theme.dart';
-import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 
 class PictogramSelector extends StatefulWidget {

--- a/frontend/lib/shared/models/file_data.dart
+++ b/frontend/lib/shared/models/file_data.dart
@@ -1,0 +1,8 @@
+import 'dart:typed_data';
+
+/// Domain-safe file representation, decoupled from any file-picker package.
+///
+/// Presentation-layer code maps platform-specific file types (e.g.
+/// `PlatformFile` from `file_picker`) to this record before passing
+/// data into cubits or repositories.
+typedef FileData = ({String name, int size, Uint8List? bytes, String? path});

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -1,13 +1,13 @@
 import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:weekplanner/core/errors/activity_failure.dart';
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/activity_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
@@ -19,11 +19,11 @@ class MockActivityRepository extends Mock implements ActivityRepository {}
 
 class MockPictogramRepository extends Mock implements PictogramRepository {}
 
-class FakePlatformFile extends Fake implements PlatformFile {}
-
 void main() {
   setUpAll(() {
-    registerFallbackValue(FakePlatformFile());
+    registerFallbackValue(
+      (name: '', size: 0, bytes: null, path: null) as FileData,
+    );
   });
   late MockActivityRepository mockActivityRepo;
   late MockPictogramRepository mockPictogramRepo;
@@ -220,7 +220,7 @@ void main() {
       final cubit = buildCubit();
       // Seed state with name and image file
       cubit.setPictogramName('test');
-      final fakeFile = PlatformFile(name: 'image.png', size: 0, bytes: Uint8List(0));
+      final FileData fakeFile = (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
       cubit.setSelectedImageFile(fakeFile);
 
       final result = await cubit.uploadPictogramFromFile();
@@ -244,7 +244,7 @@ void main() {
 
       final cubit = buildCubit();
       cubit.setPictogramName('test');
-      final fakeFile = PlatformFile(name: 'image.png', size: 0, bytes: Uint8List(0));
+      final FileData fakeFile = (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
       cubit.setSelectedImageFile(fakeFile);
 
       final result = await cubit.uploadPictogramFromFile();

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -7,12 +7,12 @@ import 'package:mocktail/mocktail.dart';
 
 import 'package:weekplanner/core/errors/activity_failure.dart';
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
-import 'package:weekplanner/shared/models/file_data.dart';
+import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/activity_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
-import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
 import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 
 class MockActivityRepository extends Mock implements ActivityRepository {}
@@ -22,7 +22,7 @@ class MockPictogramRepository extends Mock implements PictogramRepository {}
 void main() {
   setUpAll(() {
     registerFallbackValue(
-      (name: '', size: 0, bytes: null, path: null) as FileData,
+      const (name: '', size: 0, bytes: null, path: null),
     );
   });
   late MockActivityRepository mockActivityRepo;

--- a/frontend/test/features/weekplan/pictogram_repository_test.dart
+++ b/frontend/test/features/weekplan/pictogram_repository_test.dart
@@ -1,20 +1,18 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
 import 'package:weekplanner/features/weekplan/data/repositories/pictogram_repository.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/paginated_response.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/services/pictogram_api_service.dart';
 
 class MockPictogramApiService extends Mock implements PictogramApiService {}
-
-class MockPlatformFile extends Mock implements PlatformFile {}
 
 class FakeMultipartFile extends Fake implements MultipartFile {}
 
@@ -145,9 +143,12 @@ void main() {
 
   group('uploadPictogram', () {
     test('returns Right with pictogram on success', () async {
-      final mockFile = MockPlatformFile();
-      when(() => mockFile.bytes).thenReturn(Uint8List.fromList([1, 2, 3]));
-      when(() => mockFile.name).thenReturn('image.png');
+      final FileData testFile = (
+        name: 'image.png',
+        size: 3,
+        bytes: Uint8List.fromList([1, 2, 3]),
+        path: null,
+      );
 
       when(
         () => mockCore.uploadPictogram(
@@ -161,7 +162,7 @@ void main() {
 
       final result = await repo.uploadPictogram(
         name: 'Bade',
-        imageFile: mockFile,
+        imageFile: testFile,
       );
 
       expect(result, isA<Right<PictogramFailure, Pictogram>>());
@@ -169,9 +170,12 @@ void main() {
     });
 
     test('returns Left(CreatePictogramFailure) on exception', () async {
-      final mockFile = MockPlatformFile();
-      when(() => mockFile.bytes).thenReturn(Uint8List.fromList([1, 2, 3]));
-      when(() => mockFile.name).thenReturn('image.png');
+      final FileData testFile = (
+        name: 'image.png',
+        size: 3,
+        bytes: Uint8List.fromList([1, 2, 3]),
+        path: null,
+      );
 
       when(
         () => mockCore.uploadPictogram(
@@ -185,7 +189,7 @@ void main() {
 
       final result = await repo.uploadPictogram(
         name: 'Bade',
-        imageFile: mockFile,
+        imageFile: testFile,
       );
 
       expect(result, isA<Left<PictogramFailure, Pictogram>>());
@@ -196,14 +200,16 @@ void main() {
     });
 
     test('returns Left when file has neither bytes nor path', () async {
-      final mockFile = MockPlatformFile();
-      when(() => mockFile.bytes).thenReturn(null);
-      when(() => mockFile.path).thenReturn(null);
-      when(() => mockFile.name).thenReturn('broken.png');
+      const FileData brokenFile = (
+        name: 'broken.png',
+        size: 0,
+        bytes: null,
+        path: null,
+      );
 
       final result = await repo.uploadPictogram(
         name: 'Bade',
-        imageFile: mockFile,
+        imageFile: brokenFile,
       );
 
       expect(result, isA<Left<PictogramFailure, Pictogram>>());


### PR DESCRIPTION
## Summary

- Add `FileData` record typedef in `shared/models/file_data.dart` — pure Dart, no framework deps
- Replace `PlatformFile` with `FileData` in domain layer:
  - `PictogramRepository` interface
  - `ActivityFormState` (`PictogramCreation` sub-state)
  - `ActivityFormCubit` setters
- `PictogramRepositoryImpl` converts `FileData → MultipartFile` at the data boundary
- `PictogramSelector._pickFile()` converts `PlatformFile → FileData` at the presentation boundary
- No `domain/` file imports `package:file_picker`

Enforces CLAUDE.md rule: *"Domain layer is pure Dart — no Flutter imports, no framework dependencies."*

Closes #39

## Test plan

- [x] `dart analyze` — zero warnings
- [x] `flutter test` — all 191 tests pass
- [x] Verified: no domain file imports `file_picker`
- [ ] Manual: verify pictogram upload and file selection flows