### PR TITLE
fix: runtime API config and activity date bug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,9 @@
-# Weekplanner Monorepo — Environment Variables
+# Weekplanner — Environment Variables
 # Copy to .env and fill in values.
 
-# --- Backend: Database (docker-compose.prod.yml) ---
-GIRAF_DB_USER=postgres
-GIRAF_DB_PASSWORD=          # REQUIRED — set a strong password
-GIRAF_DB_NAME=giraf_prod
-GIRAF_DB_PORT=5432
+# JWT signing key — must match giraf-core (min 32 chars)
+JWT_SECRET=
 
-# --- Backend: JWT Authentication ---
-GIRAF_JWT_SECRET=           # REQUIRED — minimum 32 characters, must match giraf-core
-GIRAF_JWT_ISSUER=Giraf
-GIRAF_JWT_AUDIENCE=GirafApp
-
-# --- Backend: API ---
-GIRAF_API_PORT=5171
-
-# --- Backend: GIRAF Core ---
-GIRAF_CORE_URL=http://localhost:8000  # REQUIRED — giraf-core base URL
-
-# --- Frontend: Expo (copy to frontend/.env) ---
-EXPO_PUBLIC_API_URL="http://10.0.0.4"
-EXPO_PUBLIC_API_PORT=5171
-EXPO_PUBLIC_CORE_API_URL="http://10.0.0.4"
-EXPO_PUBLIC_CORE_API_PORT=8000
+# ASP.NET environment: Development | Production
+ASPNETCORE_ENVIRONMENT=Development
+ASPNETCORE_URLS=http://+:5171

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -101,6 +101,10 @@ GoRouter createRouter({
               final isCitizen = type == 'citizen';
               final orgId =
                   int.tryParse(state.uri.queryParameters['orgId'] ?? '');
+              final dateParam = state.uri.queryParameters['date'];
+              final initialDate = dateParam != null
+                  ? DateTime.tryParse(dateParam) ?? DateTime.now()
+                  : DateTime.now();
               final activityRepo = context.read<ActivityRepository>();
               final pictogramRepo = context.read<PictogramRepository>();
               return BlocProvider(
@@ -110,7 +114,7 @@ GoRouter createRouter({
                   subjectId: citizenId,
                   isCitizen: isCitizen,
                   organizationId: orgId,
-                  initialDate: DateTime.now(),
+                  initialDate: initialDate,
                 ),
                 child: const ActivityFormView(
                   title: 'Tilføj aktivitet',

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -143,6 +143,10 @@ GoRouter createRouter({
                 // Fallback: no activity in route extras — redirect to organisations
                 return const _RedirectWidget(target: '/organisations');
               }
+              final dateParam = state.uri.queryParameters['date'];
+              final initialDate = dateParam != null
+                  ? DateTime.tryParse(dateParam) ?? DateTime.now()
+                  : DateTime.now();
               final activityRepo = context.read<ActivityRepository>();
               final pictogramRepo = context.read<PictogramRepository>();
               return BlocProvider(
@@ -153,7 +157,7 @@ GoRouter createRouter({
                   subjectId: citizenId,
                   isCitizen: isCitizen,
                   organizationId: orgId,
-                  initialDate: DateTime.now(),
+                  initialDate: initialDate,
                 ),
                 child: const ActivityFormView(
                   title: 'Rediger aktivitet',

--- a/frontend/lib/config/api_config.dart
+++ b/frontend/lib/config/api_config.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:logging/logging.dart';
+
+final _log = Logger('ApiConfig');
 
 /// Runtime API configuration.
 ///
@@ -13,8 +16,8 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 /// Call [ApiConfig.load] once before accessing [coreBaseUrl] or
 /// [weekplannerBaseUrl].
 class ApiConfig {
-  static String _coreBaseUrl = '';
-  static String _weekplannerBaseUrl = '';
+  static late String _coreBaseUrl;
+  static late String _weekplannerBaseUrl;
 
   static String get coreBaseUrl => _coreBaseUrl;
   static String get weekplannerBaseUrl => _weekplannerBaseUrl;
@@ -37,7 +40,8 @@ class ApiConfig {
       _coreBaseUrl = config['coreBaseUrl'] as String? ?? 'http://localhost:8000';
       _weekplannerBaseUrl =
           config['weekplannerBaseUrl'] as String? ?? 'http://localhost:5171';
-    } catch (_) {
+    } catch (e) {
+      _log.warning('Failed to load web config, using defaults: $e');
       _coreBaseUrl = 'http://localhost:8000';
       _weekplannerBaseUrl = 'http://localhost:5171';
     }

--- a/frontend/lib/config/api_config.dart
+++ b/frontend/lib/config/api_config.dart
@@ -1,18 +1,54 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 
+/// Runtime API configuration.
+///
+/// On web: reads from `config.json` at the web root (edit `web/config.json`
+/// to change endpoints — no recompile needed).
+/// On mobile: uses `--dart-define` overrides or falls back to emulator-friendly
+/// defaults.
+///
+/// Call [ApiConfig.load] once before accessing [coreBaseUrl] or
+/// [weekplannerBaseUrl].
 class ApiConfig {
-  static const String _coreEnv =
-      String.fromEnvironment('CORE_BASE_URL');
-  static const String _weekplannerEnv =
-      String.fromEnvironment('WEEKPLANNER_BASE_URL');
+  static String _coreBaseUrl = '';
+  static String _weekplannerBaseUrl = '';
 
-  static String get coreBaseUrl =>
-      _coreEnv.isNotEmpty ? _coreEnv : _defaultHost(8000);
-  static String get weekplannerBaseUrl =>
-      _weekplannerEnv.isNotEmpty ? _weekplannerEnv : _defaultHost(5171);
+  static String get coreBaseUrl => _coreBaseUrl;
+  static String get weekplannerBaseUrl => _weekplannerBaseUrl;
 
-  /// On web, localhost is reachable directly.
-  /// On Android emulator, 10.0.2.2 maps to the host machine's localhost.
-  static String _defaultHost(int port) =>
-      kIsWeb ? 'http://localhost:$port' : 'http://10.0.2.2:$port';
+  /// Load configuration. Must be called once at startup (in main).
+  static Future<void> load() async {
+    if (kIsWeb) {
+      await _loadWebConfig();
+    } else {
+      _loadMobileConfig();
+    }
+  }
+
+  static Future<void> _loadWebConfig() async {
+    try {
+      // Dio is already a dependency — use it to fetch the config served
+      // alongside the app at the web root.
+      final response = await Dio().get<String>('config.json');
+      final config = jsonDecode(response.data!) as Map<String, dynamic>;
+      _coreBaseUrl = config['coreBaseUrl'] as String? ?? 'http://localhost:8000';
+      _weekplannerBaseUrl =
+          config['weekplannerBaseUrl'] as String? ?? 'http://localhost:5171';
+    } catch (_) {
+      _coreBaseUrl = 'http://localhost:8000';
+      _weekplannerBaseUrl = 'http://localhost:5171';
+    }
+  }
+
+  static void _loadMobileConfig() {
+    const coreEnv = String.fromEnvironment('CORE_BASE_URL');
+    const wpEnv = String.fromEnvironment('WEEKPLANNER_BASE_URL');
+    _coreBaseUrl =
+        coreEnv.isNotEmpty ? coreEnv : 'http://10.0.2.2:8000';
+    _weekplannerBaseUrl =
+        wpEnv.isNotEmpty ? wpEnv : 'http://10.0.2.2:5171';
+  }
 }

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -185,9 +185,11 @@ class _ActivityList extends StatelessWidget {
             imageUrl: media?.imageUrl,
             soundUrl: media?.soundUrl,
             onEdit: () async {
+              final dateStr =
+                  activity.date.toIso8601String().split('T').first;
               final saved = await context.push<bool>(
                 '/weekplan/$citizenId/edit/${activity.activityId}'
-                '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId',
+                '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
                 extra: activity,
               );
               if (saved == true && context.mounted) {

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -30,8 +30,10 @@ class WeekplanView extends StatelessWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
+          final selectedDate = context.read<WeekplanCubit>().state.selectedDate;
+          final dateStr = selectedDate.toIso8601String().split('T').first;
           final saved = await context.push<bool>(
-            '/weekplan/$citizenId/add?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId',
+            '/weekplan/$citizenId/add?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
           );
           if (saved == true && context.mounted) {
             context.read<WeekplanCubit>().loadActivities();

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -32,6 +32,7 @@ Dio _createDio(String baseUrl) => Dio(BaseOptions(
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await setupLogging();
+  await ApiConfig.load();
 
   // Dio instances — created here so the refresh interceptor can be shared.
   final coreDio = _createDio(ApiConfig.coreBaseUrl);

--- a/frontend/test/config/api_config_test.dart
+++ b/frontend/test/config/api_config_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:weekplanner/config/api_config.dart';
+
+void main() {
+  group('ApiConfig', () {
+    test('load sets emulator defaults on mobile (no dart-define)', () async {
+      // On non-web platform with no --dart-define overrides,
+      // load() should fall back to Android emulator defaults.
+      await ApiConfig.load();
+
+      expect(ApiConfig.coreBaseUrl, 'http://10.0.2.2:8000');
+      expect(ApiConfig.weekplannerBaseUrl, 'http://10.0.2.2:5171');
+    });
+  });
+}

--- a/frontend/web/config.json
+++ b/frontend/web/config.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Points at the AAU Strato test server. Change these URLs to target a different environment.",
   "coreBaseUrl": "http://130.225.39.225:8000",
   "weekplannerBaseUrl": "http://130.225.39.225:5171"
 }

--- a/frontend/web/config.json
+++ b/frontend/web/config.json
@@ -1,0 +1,4 @@
+{
+  "coreBaseUrl": "http://130.225.39.225:8000",
+  "weekplannerBaseUrl": "http://130.225.39.225:5171"
+}


### PR DESCRIPTION
## Summary
- Replace compile-time `--dart-define` with runtime `web/config.json` for API base URLs — students edit one file, no CLI flags to remember
- Fix activity form always using today's date instead of the selected weekplan date
- Simplify `.env.example` for compose `env_file` setup

## Test plan
- [ ] `flutter run -d chrome` loads URLs from `web/config.json`
- [ ] Navigate to a future date, add activity — it appears on that date, not today
- [ ] Mobile still works with `--dart-define` fallback