### PR TITLE
feat: child-friendly activity cards with title, reorder, and optional time

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Restore
         run: dotnet restore weekplanner-api.sln
 
-      - name: Build
-        run: dotnet build weekplanner-api.sln -c Release --no-restore
+      - name: Check formatting
+        run: dotnet format weekplanner-api.sln --verify-no-changes --verbosity diagnostic
+
+      - name: Build (warnings as errors)
+        run: dotnet build weekplanner-api.sln -c Release --no-restore -warnaserror
 
       - name: Test
         run: dotnet test weekplanner-api.sln -c Release --no-build --verbosity normal

--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -145,6 +145,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 PictogramId: 1
             );
 
@@ -172,6 +174,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 PictogramId: null
             );
 
@@ -200,6 +204,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 PictogramId: 1
             );
 
@@ -226,6 +232,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 PictogramId: null
             );
 
@@ -255,6 +263,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: true,
                 PictogramId: 1
             );
@@ -288,6 +298,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: TimeOnly.FromDateTime(DateTime.UtcNow),
                 EndTime: TimeOnly.FromDateTime(DateTime.UtcNow.AddHours(1)),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: false,
                 PictogramId: null
             );
@@ -455,6 +467,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(10, 0),
                 EndTime: new TimeOnly(8, 0),
+                Title: null,
+                SortOrder: null,
                 PictogramId: null
             );
 
@@ -478,6 +492,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(10, 0),
                 EndTime: new TimeOnly(8, 0),
+                Title: null,
+                SortOrder: null,
                 PictogramId: null
             );
 
@@ -537,6 +553,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(14, 0),
                 EndTime: new TimeOnly(12, 0),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: false,
                 PictogramId: null
             );
@@ -733,6 +751,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(10, 0),
                 EndTime: new TimeOnly(11, 0),
+                Title: null,
+                SortOrder: null,
                 PictogramId: null
             );
 
@@ -755,6 +775,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(10, 0),
                 EndTime: new TimeOnly(11, 0),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: false,
                 PictogramId: null
             );
@@ -898,6 +920,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(9, 0),
                 EndTime: new TimeOnly(10, 0),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: false,
                 PictogramId: null
             );
@@ -1001,6 +1025,8 @@ namespace Giraf.IntegrationTests.Endpoints
                 Date: DateOnly.FromDateTime(DateTime.UtcNow),
                 StartTime: new TimeOnly(9, 0),
                 EndTime: new TimeOnly(10, 0),
+                Title: null,
+                SortOrder: null,
                 IsCompleted: false,
                 PictogramId: null
             );

--- a/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
+++ b/backend/Giraf.IntegrationTests/Endpoints/ActivityEndpointTests.cs
@@ -1053,5 +1053,220 @@ namespace Giraf.IntegrationTests.Endpoints
         }
 
         #endregion
+
+        #region New feature tests — Title, SortOrder, optional time, reorder
+
+        [Fact]
+        public async Task CreateActivity_WithTitle_RoundTripsCorrectly()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var dto = new CreateActivityDTO(
+                Date: DateOnly.FromDateTime(DateTime.UtcNow),
+                StartTime: new TimeOnly(8, 0),
+                EndTime: new TimeOnly(9, 0),
+                Title: "Morgenmad",
+                SortOrder: null,
+                PictogramId: null
+            );
+
+            var response = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto);
+
+            response.EnsureSuccessStatusCode();
+            var activity = await response.Content.ReadFromJsonAsync<ActivityDTO>();
+            Assert.NotNull(activity);
+            Assert.Equal("Morgenmad", activity.Title);
+        }
+
+        [Fact]
+        public async Task CreateActivity_WithoutTime_ReturnsCreated()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var dto = new CreateActivityDTO(
+                Date: DateOnly.FromDateTime(DateTime.UtcNow),
+                StartTime: null,
+                EndTime: null,
+                Title: "Frikvarter",
+                SortOrder: null,
+                PictogramId: null
+            );
+
+            var response = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto);
+
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            var activity = await response.Content.ReadFromJsonAsync<ActivityDTO>();
+            Assert.NotNull(activity);
+            Assert.Null(activity.StartTime);
+            Assert.Null(activity.EndTime);
+            Assert.Equal("Frikvarter", activity.Title);
+        }
+
+        [Fact]
+        public async Task CreateActivity_AutoAssignsSortOrder()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var date = DateOnly.FromDateTime(DateTime.UtcNow);
+
+            var dto1 = new CreateActivityDTO(
+                Date: date,
+                StartTime: null,
+                EndTime: null,
+                Title: "First",
+                SortOrder: null,
+                PictogramId: null
+            );
+            var dto2 = new CreateActivityDTO(
+                Date: date,
+                StartTime: null,
+                EndTime: null,
+                Title: "Second",
+                SortOrder: null,
+                PictogramId: null
+            );
+
+            var r1 = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto1);
+            var r2 = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto2);
+
+            r1.EnsureSuccessStatusCode();
+            r2.EnsureSuccessStatusCode();
+            var a1 = await r1.Content.ReadFromJsonAsync<ActivityDTO>();
+            var a2 = await r2.Content.ReadFromJsonAsync<ActivityDTO>();
+            Assert.NotNull(a1);
+            Assert.NotNull(a2);
+            Assert.True(a2.SortOrder > a1.SortOrder);
+        }
+
+        [Fact]
+        public async Task ReorderActivities_UpdatesOrder()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var date = DateOnly.FromDateTime(DateTime.UtcNow);
+
+            // Create two activities
+            var dto1 = new CreateActivityDTO(Date: date, StartTime: null, EndTime: null,
+                Title: "A", SortOrder: null, PictogramId: null);
+            var dto2 = new CreateActivityDTO(Date: date, StartTime: null, EndTime: null,
+                Title: "B", SortOrder: null, PictogramId: null);
+
+            var r1 = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto1);
+            var r2 = await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto2);
+            var a1 = await r1.Content.ReadFromJsonAsync<ActivityDTO>();
+            var a2 = await r2.Content.ReadFromJsonAsync<ActivityDTO>();
+            Assert.NotNull(a1);
+            Assert.NotNull(a2);
+
+            // Swap their order
+            var reorderItems = new List<ReorderItemDTO>
+            {
+                new(a1.ActivityId, 1),
+                new(a2.ActivityId, 0)
+            };
+
+            var reorderResponse = await client.PutAsJsonAsync("/weekplan/reorder/1", reorderItems);
+            reorderResponse.EnsureSuccessStatusCode();
+
+            // Verify new order
+            var getResponse = await client.GetAsync($"/weekplan/1?date={date:yyyy-MM-dd}");
+            var activities = await getResponse.Content.ReadFromJsonAsync<List<ActivityDTO>>();
+            Assert.NotNull(activities);
+            Assert.True(activities.Count >= 2);
+            // B (sortOrder 0) should come before A (sortOrder 1)
+            var bIndex = activities.FindIndex(a => a.ActivityId == a2.ActivityId);
+            var aIndex = activities.FindIndex(a => a.ActivityId == a1.ActivityId);
+            Assert.True(bIndex < aIndex, "Activity B should appear before Activity A after reorder");
+        }
+
+        [Fact]
+        public async Task ReorderActivities_ReturnsUnauthorized_WhenNoToken()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new EmptyDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+
+            var items = new List<ReorderItemDTO> { new(1, 0) };
+            var response = await client.PutAsJsonAsync("/weekplan/reorder/1", items);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetActivities_ReturnsSortedBySortOrderThenStartTime()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "member");
+
+            var date = DateOnly.FromDateTime(DateTime.UtcNow);
+
+            // Create activities with explicit sort orders (reverse of time)
+            var dto1 = new CreateActivityDTO(Date: date, StartTime: new TimeOnly(8, 0),
+                EndTime: new TimeOnly(9, 0), Title: "Early but second", SortOrder: 1, PictogramId: null);
+            var dto2 = new CreateActivityDTO(Date: date, StartTime: new TimeOnly(10, 0),
+                EndTime: new TimeOnly(11, 0), Title: "Late but first", SortOrder: 0, PictogramId: null);
+
+            await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto1);
+            await client.PostAsJsonAsync("/weekplan/to-citizen/1", dto2);
+
+            var response = await client.GetAsync($"/weekplan/1?date={date:yyyy-MM-dd}");
+            var activities = await response.Content.ReadFromJsonAsync<List<ActivityDTO>>();
+            Assert.NotNull(activities);
+            Assert.True(activities.Count >= 2);
+
+            // "Late but first" (sortOrder 0) should come before "Early but second" (sortOrder 1)
+            var firstIdx = activities.FindIndex(a => a.Title == "Late but first");
+            var secondIdx = activities.FindIndex(a => a.Title == "Early but second");
+            Assert.True(firstIdx < secondIdx, "SortOrder should take priority over StartTime");
+        }
+
+        [Fact]
+        public async Task GetActivitiesForGrade_ReturnsEmptyList_WhenNoActivities()
+        {
+            var factory = new GirafWebApplicationFactory(stubCoreClient: true);
+            var seeder = new BaseCaseDb();
+            var scope = factory.Services.CreateScope();
+            factory.SeedDb(scope, seeder);
+            var client = factory.CreateClient();
+            client.AttachClaimsToken(role: "admin");
+
+            // Use a future date where no activities exist
+            var futureDate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(1));
+            var response = await client.GetAsync($"/weekplan/grade/1?date={futureDate:yyyy-MM-dd}");
+
+            response.EnsureSuccessStatusCode();
+            var activities = await response.Content.ReadFromJsonAsync<List<ActivityDTO>>();
+            Assert.NotNull(activities);
+            Assert.Empty(activities);
+        }
+
+        #endregion
     }
 }

--- a/backend/Giraf.IntegrationTests/Utils/TestJwtToken.cs
+++ b/backend/Giraf.IntegrationTests/Utils/TestJwtToken.cs
@@ -18,7 +18,7 @@ public class TestJwtToken
             claims: claims,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);
-        
+
         var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
         return tokenString;
     }

--- a/backend/GirafAPI/Data/Migrations/20260402081415_AddTitleSortOrderOptionalTime.Designer.cs
+++ b/backend/GirafAPI/Data/Migrations/20260402081415_AddTitleSortOrderOptionalTime.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GirafAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GirafAPI.Data.Migrations
 {
     [DbContext(typeof(GirafDbContext))]
-    partial class GirafDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260402081415_AddTitleSortOrderOptionalTime")]
+    partial class AddTitleSortOrderOptionalTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/GirafAPI/Data/Migrations/20260402081415_AddTitleSortOrderOptionalTime.cs
+++ b/backend/GirafAPI/Data/Migrations/20260402081415_AddTitleSortOrderOptionalTime.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GirafAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTitleSortOrderOptionalTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "StartTime",
+                table: "Activities",
+                type: "time without time zone",
+                nullable: true,
+                oldClrType: typeof(TimeOnly),
+                oldType: "time without time zone");
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "EndTime",
+                table: "Activities",
+                type: "time without time zone",
+                nullable: true,
+                oldClrType: typeof(TimeOnly),
+                oldType: "time without time zone");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SortOrder",
+                table: "Activities",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "Activities",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SortOrder",
+                table: "Activities");
+
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "Activities");
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "StartTime",
+                table: "Activities",
+                type: "time without time zone",
+                nullable: false,
+                defaultValue: new TimeOnly(0, 0, 0),
+                oldClrType: typeof(TimeOnly),
+                oldType: "time without time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<TimeOnly>(
+                name: "EndTime",
+                table: "Activities",
+                type: "time without time zone",
+                nullable: false,
+                defaultValue: new TimeOnly(0, 0, 0),
+                oldClrType: typeof(TimeOnly),
+                oldType: "time without time zone",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/GirafAPI/Data/Migrations/20260402082454_AddTitleSortOrderOptionalTime.Designer.cs
+++ b/backend/GirafAPI/Data/Migrations/20260402082454_AddTitleSortOrderOptionalTime.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GirafAPI.Data.Migrations
 {
     [DbContext(typeof(GirafDbContext))]
-    [Migration("20260402081415_AddTitleSortOrderOptionalTime")]
+    [Migration("20260402082454_AddTitleSortOrderOptionalTime")]
     partial class AddTitleSortOrderOptionalTime
     {
         /// <inheritdoc />
@@ -58,7 +58,8 @@ namespace GirafAPI.Data.Migrations
                         .HasColumnType("time without time zone");
 
                     b.Property<string>("Title")
-                        .HasColumnType("text");
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
 
                     b.HasKey("Id");
 

--- a/backend/GirafAPI/Data/Migrations/20260402082454_AddTitleSortOrderOptionalTime.cs
+++ b/backend/GirafAPI/Data/Migrations/20260402082454_AddTitleSortOrderOptionalTime.cs
@@ -37,7 +37,8 @@ namespace GirafAPI.Data.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "Title",
                 table: "Activities",
-                type: "text",
+                type: "character varying(200)",
+                maxLength: 200,
                 nullable: true);
         }
 

--- a/backend/GirafAPI/Data/Migrations/GirafDbContextModelSnapshot.cs
+++ b/backend/GirafAPI/Data/Migrations/GirafDbContextModelSnapshot.cs
@@ -55,7 +55,8 @@ namespace GirafAPI.Data.Migrations
                         .HasColumnType("time without time zone");
 
                     b.Property<string>("Title")
-                        .HasColumnType("text");
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
 
                     b.HasKey("Id");
 

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -175,6 +175,52 @@ public static class ActivityEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status200OK);
 
+        // PUT reorder activities for citizen
+        group.MapPut("/reorder/{citizenId:int}",
+                async Task<IResult> (int citizenId, List<ReorderItemDTO> items,
+                    IActivityService service, HttpContext httpContext, CancellationToken ct) =>
+                {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.ReorderActivitiesAsync(
+                        new ActivityOwner.Citizen(citizenId), items, token, ct);
+                    return result.ToHttpResult(() => TypedResults.Ok());
+                })
+            .WithName("ReorderActivitiesForCitizen")
+            .WithDescription("Reorders activities for a citizen.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Accepts<List<ReorderItemDTO>>("application/json")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status400BadRequest);
+
+        // PUT reorder activities for grade
+        group.MapPut("/reorder/grade/{gradeId:int}",
+                async Task<IResult> (int gradeId, List<ReorderItemDTO> items,
+                    IActivityService service, HttpContext httpContext, CancellationToken ct) =>
+                {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.ReorderActivitiesAsync(
+                        new ActivityOwner.Grade(gradeId), items, token, ct);
+                    return result.ToHttpResult(() => TypedResults.Ok());
+                })
+            .WithName("ReorderActivitiesForGrade")
+            .WithDescription("Reorders activities for a grade.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Accepts<List<ReorderItemDTO>>("application/json")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status400BadRequest);
+
         // PUT updated activity
         group.MapPut("/activity/{id:int}",
                 async Task<IResult> (int id, UpdateActivityDTO dto, IActivityService service,

--- a/backend/GirafAPI/Entities/Activities/Activity.cs
+++ b/backend/GirafAPI/Entities/Activities/Activity.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace GirafAPI.Entities.Activities;
 
 // Data model of one activity in a day
@@ -11,6 +13,7 @@ public class Activity
 
     public TimeOnly? EndTime { get; set; }
 
+    [MaxLength(200)]
     public string? Title { get; set; }
 
     public int SortOrder { get; set; }

--- a/backend/GirafAPI/Entities/Activities/Activity.cs
+++ b/backend/GirafAPI/Entities/Activities/Activity.cs
@@ -7,9 +7,13 @@ public class Activity
 
     public required DateOnly Date { get; set; }
 
-    public required TimeOnly StartTime { get; set; }
+    public TimeOnly? StartTime { get; set; }
 
-    public required TimeOnly EndTime { get; set; }
+    public TimeOnly? EndTime { get; set; }
+
+    public string? Title { get; set; }
+
+    public int SortOrder { get; set; }
 
     public bool IsCompleted { get; set; }
 

--- a/backend/GirafAPI/Entities/Activities/DTOs/ActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/ActivityDTO.cs
@@ -6,8 +6,10 @@ public record ActivityDTO
 (
     [Required] int ActivityId,
     [Required] DateOnly Date,
-    [Required] TimeOnly StartTime,
-    [Required] TimeOnly EndTime,
+    TimeOnly? StartTime,
+    TimeOnly? EndTime,
+    string? Title,
+    int SortOrder,
     bool IsCompleted,
     int? PictogramId
 );

--- a/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
@@ -5,7 +5,9 @@ namespace GirafAPI.Entities.Activities.DTOs;
 public record CreateActivityDTO
 (
     [Required] DateOnly Date,
-    [Required] TimeOnly StartTime,
-    [Required] TimeOnly EndTime,
+    TimeOnly? StartTime,
+    TimeOnly? EndTime,
+    string? Title,
+    int? SortOrder,
     int? PictogramId
 );

--- a/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
@@ -7,7 +7,7 @@ public record CreateActivityDTO
     [Required] DateOnly Date,
     TimeOnly? StartTime,
     TimeOnly? EndTime,
-    string? Title,
+    [StringLength(200)] string? Title,
     int? SortOrder,
     int? PictogramId
 );

--- a/backend/GirafAPI/Entities/Activities/DTOs/ReorderItemDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/ReorderItemDTO.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GirafAPI.Entities.Activities.DTOs;
+
+public record ReorderItemDTO
+(
+    [Required] int ActivityId,
+    [Required] int SortOrder
+);

--- a/backend/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
@@ -7,7 +7,7 @@ public record UpdateActivityDTO
     [Required] DateOnly Date,
     TimeOnly? StartTime,
     TimeOnly? EndTime,
-    string? Title,
+    [StringLength(200)] string? Title,
     int? SortOrder,
     [Required] bool IsCompleted,
     int? PictogramId

--- a/backend/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/UpdateActivityDTO.cs
@@ -5,8 +5,10 @@ namespace GirafAPI.Entities.Activities.DTOs;
 public record UpdateActivityDTO
 (
     [Required] DateOnly Date,
-    [Required] TimeOnly StartTime,
-    [Required] TimeOnly EndTime,
+    TimeOnly? StartTime,
+    TimeOnly? EndTime,
+    string? Title,
+    int? SortOrder,
     [Required] bool IsCompleted,
     int? PictogramId
 );

--- a/backend/GirafAPI/Mapping/ActivityMapping.cs
+++ b/backend/GirafAPI/Mapping/ActivityMapping.cs
@@ -12,6 +12,8 @@ public static class ActivityMapping
             Date = dto.Date,
             StartTime = dto.StartTime,
             EndTime = dto.EndTime,
+            Title = dto.Title,
+            SortOrder = dto.SortOrder ?? 0,
             IsCompleted = false,
             PictogramId = dto.PictogramId
         };
@@ -25,6 +27,8 @@ public static class ActivityMapping
             Date = dto.Date,
             StartTime = dto.StartTime,
             EndTime = dto.EndTime,
+            Title = dto.Title,
+            SortOrder = dto.SortOrder ?? 0,
             IsCompleted = dto.IsCompleted,
             PictogramId = dto.PictogramId
         };
@@ -37,6 +41,8 @@ public static class ActivityMapping
             activity.Date,
             activity.StartTime,
             activity.EndTime,
+            activity.Title,
+            activity.SortOrder,
             activity.IsCompleted,
             activity.PictogramId
         );

--- a/backend/GirafAPI/Mapping/ActivityMapping.cs
+++ b/backend/GirafAPI/Mapping/ActivityMapping.cs
@@ -19,21 +19,6 @@ public static class ActivityMapping
         };
     }
 
-    public static Activity ToEntity(this UpdateActivityDTO dto, int id)
-    {
-        return new Activity
-        {
-            Id = id,
-            Date = dto.Date,
-            StartTime = dto.StartTime,
-            EndTime = dto.EndTime,
-            Title = dto.Title,
-            SortOrder = dto.SortOrder ?? 0,
-            IsCompleted = dto.IsCompleted,
-            PictogramId = dto.PictogramId
-        };
-    }
-
     public static ActivityDTO ToDTO(this Activity activity)
     {
         return new ActivityDTO(

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -28,14 +28,13 @@ public class ActivityService : IActivityService
         var activities = await _db.Activities
             .Where(owner.ToFilter())
             .Where(a => a.Date == date)
+            .OrderBy(a => a.SortOrder)
+            .ThenBy(a => a.StartTime)
             .Select(a => a.ToDTO())
             .AsNoTracking()
             .ToListAsync(ct);
 
-        return owner is ActivityOwner.Grade && activities.Count == 0
-            ? ServiceResult<List<ActivityDTO>>.Fail(
-                new ServiceError(ServiceErrorKind.NotFound, "No activities found for the given date."))
-            : ServiceResult<List<ActivityDTO>>.Success(activities);
+        return ServiceResult<List<ActivityDTO>>.Success(activities);
     }
 
     public async Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, string accessToken, CancellationToken ct = default)
@@ -58,7 +57,7 @@ public class ActivityService : IActivityService
     public async Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
         ActivityOwner owner, CreateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {
-        if (dto.EndTime <= dto.StartTime)
+        if (dto.StartTime is not null && dto.EndTime is not null && dto.EndTime <= dto.StartTime)
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));
 
@@ -76,6 +75,16 @@ public class ActivityService : IActivityService
         var activity = dto.ToEntity();
         owner.ApplyTo(activity);
 
+        // Auto-assign sort order if not provided
+        if (dto.SortOrder is null)
+        {
+            var maxOrder = await _db.Activities
+                .Where(owner.ToFilter())
+                .Where(a => a.Date == dto.Date)
+                .MaxAsync(a => (int?)a.SortOrder, ct) ?? -1;
+            activity.SortOrder = maxOrder + 1;
+        }
+
         _db.Activities.Add(activity);
         await _db.SaveChangesAsync(ct);
 
@@ -85,7 +94,7 @@ public class ActivityService : IActivityService
     public async Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {
-        if (dto.EndTime <= dto.StartTime)
+        if (dto.StartTime is not null && dto.EndTime is not null && dto.EndTime <= dto.StartTime)
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));
 
@@ -107,6 +116,9 @@ public class ActivityService : IActivityService
         activity.Date = dto.Date;
         activity.StartTime = dto.StartTime;
         activity.EndTime = dto.EndTime;
+        activity.Title = dto.Title;
+        if (dto.SortOrder is not null)
+            activity.SortOrder = dto.SortOrder.Value;
         activity.IsCompleted = dto.IsCompleted;
         activity.PictogramId = dto.PictogramId;
         await _db.SaveChangesAsync(ct);
@@ -191,12 +203,39 @@ public class ActivityService : IActivityService
                 Date = targetDate,
                 StartTime = a.StartTime,
                 EndTime = a.EndTime,
+                Title = a.Title,
+                SortOrder = a.SortOrder,
                 IsCompleted = false,
                 PictogramId = a.PictogramId
             };
             owner.ApplyTo(copy);
             _db.Activities.Add(copy);
         }
+
+        await _db.SaveChangesAsync(ct);
+        return ServiceResult.Success();
+    }
+
+    public async Task<ServiceResult> ReorderActivitiesAsync(
+        ActivityOwner owner, List<ReorderItemDTO> items, string accessToken, CancellationToken ct = default)
+    {
+        var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+        if (ownerResult is not null)
+            return ServiceResult.Fail(ownerResult);
+
+        var ids = items.Select(i => i.ActivityId).ToList();
+        var activities = await _db.Activities
+            .Where(owner.ToFilter())
+            .Where(a => ids.Contains(a.Id))
+            .ToListAsync(ct);
+
+        if (activities.Count != ids.Count)
+            return ServiceResult.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "One or more activity IDs are invalid."));
+
+        var orderMap = items.ToDictionary(i => i.ActivityId, i => i.SortOrder);
+        foreach (var activity in activities)
+            activity.SortOrder = orderMap[activity.Id];
 
         await _db.SaveChangesAsync(ct);
         return ServiceResult.Success();

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -57,6 +57,10 @@ public class ActivityService : IActivityService
     public async Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
         ActivityOwner owner, CreateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {
+        if ((dto.StartTime is null) != (dto.EndTime is null))
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "Start and end time must both be provided or both omitted."));
+
         if (dto.StartTime is not null && dto.EndTime is not null && dto.EndTime <= dto.StartTime)
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));
@@ -94,6 +98,10 @@ public class ActivityService : IActivityService
     public async Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {
+        if ((dto.StartTime is null) != (dto.EndTime is null))
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "Start and end time must both be provided or both omitted."));
+
         if (dto.StartTime is not null && dto.EndTime is not null && dto.EndTime <= dto.StartTime)
             return ServiceResult<ActivityDTO>.Fail(
                 new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -117,6 +117,7 @@ public class ActivityService : IActivityService
         activity.StartTime = dto.StartTime;
         activity.EndTime = dto.EndTime;
         activity.Title = dto.Title;
+        // Preserve existing sort order when client omits it (e.g. simple field edits).
         if (dto.SortOrder is not null)
             activity.SortOrder = dto.SortOrder.Value;
         activity.IsCompleted = dto.IsCompleted;

--- a/backend/GirafAPI/Services/IActivityService.cs
+++ b/backend/GirafAPI/Services/IActivityService.cs
@@ -22,4 +22,7 @@ public interface IActivityService
 
     Task<ServiceResult> CopyActivitiesAsync(
         ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, string accessToken, CancellationToken ct = default);
+
+    Task<ServiceResult> ReorderActivitiesAsync(
+        ActivityOwner owner, List<ReorderItemDTO> items, string accessToken, CancellationToken ct = default);
 }

--- a/frontend/lib/core/errors/activity_failure.dart
+++ b/frontend/lib/core/errors/activity_failure.dart
@@ -35,3 +35,9 @@ final class ToggleStatusFailure extends ActivityFailure {
   const ToggleStatusFailure()
       : super('Kunne ikke ændre status');
 }
+
+/// Failed to reorder activities.
+final class ReorderActivitiesFailure extends ActivityFailure {
+  const ReorderActivitiesFailure()
+      : super('Kunne ikke ændre rækkefølge');
+}

--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -93,4 +93,31 @@ class ActivityRepositoryImpl implements ActivityRepository {
       return Left(const ToggleStatusFailure());
     }
   }
+
+  @override
+  Future<Either<ActivityFailure, Unit>> reorderActivities({
+    required int id,
+    required bool isCitizen,
+    required List<Activity> activities,
+  }) async {
+    try {
+      final items = activities
+          .asMap()
+          .entries
+          .map((e) => {
+                'activityId': e.value.activityId,
+                'sortOrder': e.key,
+              })
+          .toList();
+      await _apiService.reorderActivities(
+        id: id,
+        isCitizen: isCitizen,
+        items: items,
+      );
+      return const Right(unit);
+    } catch (e, stackTrace) {
+      _log.severe('Failed to reorder activities', e, stackTrace);
+      return Left(const ReorderActivitiesFailure());
+    }
+  }
 }

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -12,10 +12,16 @@ enum PictogramMode { search, upload, generate }
 
 /// Core activity form fields: when it happens and which activity is edited.
 final class ActivityFormData with EquatableMixin {
-  /// Start time of the activity.
+  /// Title/label for the activity.
+  final String title;
+
+  /// Whether the user wants to specify a time for this activity.
+  final bool hasTime;
+
+  /// Start time of the activity (only relevant when [hasTime] is true).
   final TimeValue startTime;
 
-  /// End time of the activity.
+  /// End time of the activity (only relevant when [hasTime] is true).
   final TimeValue endTime;
 
   /// Date of the activity.
@@ -25,6 +31,8 @@ final class ActivityFormData with EquatableMixin {
   final Activity? existingActivity;
 
   const ActivityFormData({
+    this.title = '',
+    this.hasTime = false,
     this.startTime = const (hour: 8, minute: 0),
     this.endTime = const (hour: 9, minute: 0),
     required this.date,
@@ -35,6 +43,8 @@ final class ActivityFormData with EquatableMixin {
   bool get isEditing => existingActivity != null;
 
   ActivityFormData copyWith({
+    String? title,
+    bool? hasTime,
     TimeValue? startTime,
     TimeValue? endTime,
     DateTime? date,
@@ -42,6 +52,8 @@ final class ActivityFormData with EquatableMixin {
     bool clearExistingActivity = false,
   }) {
     return ActivityFormData(
+      title: title ?? this.title,
+      hasTime: hasTime ?? this.hasTime,
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
       date: date ?? this.date,
@@ -52,7 +64,8 @@ final class ActivityFormData with EquatableMixin {
   }
 
   @override
-  List<Object?> get props => [startTime, endTime, date, existingActivity];
+  List<Object?> get props =>
+      [title, hasTime, startTime, endTime, date, existingActivity];
 }
 
 // ── Sub-state: Pictogram selection ─────────────────────────

--- a/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
@@ -33,4 +33,11 @@ abstract interface class ActivityRepository {
     int activityId, {
     required bool isComplete,
   });
+
+  /// Reorder activities for a citizen or grade.
+  Future<Either<ActivityFailure, Unit>> reorderActivities({
+    required int id,
+    required bool isCitizen,
+    required List<Activity> activities,
+  });
 }

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -41,6 +41,8 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         super(ActivityFormReady(
           form: ActivityFormData(
             date: existingActivity?.date ?? initialDate,
+            title: existingActivity?.title ?? '',
+            hasTime: existingActivity?.startTime != null,
             startTime:
                 existingActivity?.startTime ?? const (hour: 8, minute: 0),
             endTime: existingActivity?.endTime ?? const (hour: 9, minute: 0),
@@ -52,6 +54,14 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         ));
 
   // ── Form field setters ────────────────────────────────────
+
+  void setTitle(String title) {
+    _emitReady(form: state.form.copyWith(title: title));
+  }
+
+  void toggleHasTime() {
+    _emitReady(form: state.form.copyWith(hasTime: !state.form.hasTime));
+  }
 
   void setStartTime(TimeValue time) {
     _emitReady(form: state.form.copyWith(startTime: time));
@@ -199,12 +209,14 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Validate the form and return an error message, or null if valid.
   String? validate() {
-    final startMinutes =
-        state.form.startTime.hour * 60 + state.form.startTime.minute;
-    final endMinutes =
-        state.form.endTime.hour * 60 + state.form.endTime.minute;
-    if (endMinutes <= startMinutes) {
-      return 'Sluttid skal være efter starttid';
+    if (state.form.hasTime) {
+      final startMinutes =
+          state.form.startTime.hour * 60 + state.form.startTime.minute;
+      final endMinutes =
+          state.form.endTime.hour * 60 + state.form.endTime.minute;
+      if (endMinutes <= startMinutes) {
+        return 'Sluttid skal være efter starttid';
+      }
     }
     return null;
   }
@@ -227,8 +239,11 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
     final data = {
       'date': GirafDateUtils.formatQueryDate(s.form.date),
-      'startTime': formatTimeValueForApi(s.form.startTime),
-      'endTime': formatTimeValueForApi(s.form.endTime),
+      if (s.form.hasTime)
+        'startTime': formatTimeValueForApi(s.form.startTime),
+      if (s.form.hasTime)
+        'endTime': formatTimeValueForApi(s.form.endTime),
+      if (s.form.title.isNotEmpty) 'title': s.form.title,
       if (s.selection.id != null) 'pictogramId': s.selection.id,
     };
 

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -248,9 +248,10 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     };
 
     final Either<ActivityFailure, Activity> result;
-    if (s.form.isEditing) {
+    final existing = s.form.existingActivity;
+    if (existing != null) {
       result = await _activityRepository.updateActivity(
-          s.form.existingActivity!.activityId, data);
+          existing.activityId, data);
     } else {
       result = await _activityRepository.createActivity(
         id: subjectId,

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -8,7 +8,7 @@ import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.d
 import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_selector.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
-class ActivityFormView extends StatelessWidget {
+class ActivityFormView extends StatefulWidget {
   const ActivityFormView({
     super.key,
     required this.title,
@@ -19,10 +19,30 @@ class ActivityFormView extends StatelessWidget {
   final String submitLabel;
 
   @override
+  State<ActivityFormView> createState() => _ActivityFormViewState();
+}
+
+class _ActivityFormViewState extends State<ActivityFormView> {
+  late final TextEditingController _titleController;
+
+  @override
+  void initState() {
+    super.initState();
+    final cubit = context.read<ActivityFormCubit>();
+    _titleController = TextEditingController(text: cubit.state.form.title);
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: Text(widget.title),
       ),
       body: BlocConsumer<ActivityFormCubit, ActivityFormState>(
         listener: (context, state) {
@@ -33,86 +53,113 @@ class ActivityFormView extends StatelessWidget {
         builder: (context, state) {
           final isSaving = state is ActivityFormSaving;
           final error = state is ActivityFormReady ? state.error : null;
-          return SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      child: _TimePicker(
-                        label: 'Starttid',
-                        time: state.form.startTime,
-                        onTap: () async {
-                          final picked = await showTimePicker(
-                            context: context,
-                            initialTime: TimeOfDay(
-                              hour: state.form.startTime.hour,
-                              minute: state.form.startTime.minute,
-                            ),
-                          );
-                          if (picked != null && context.mounted) {
-                            context.read<ActivityFormCubit>().setStartTime(
-                                  (hour: picked.hour, minute: picked.minute),
-                                );
-                          }
-                        },
-                      ),
+          final cubit = context.read<ActivityFormCubit>();
+          return IgnorePointer(
+            ignoring: isSaving,
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Title field
+                  TextField(
+                    decoration: const InputDecoration(
+                      labelText: 'Titel',
+                      hintText: 'F.eks. Morgenmad, Samling, Frikvarter',
+                      prefixIcon: Icon(Icons.label_outline),
                     ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: _TimePicker(
-                        label: 'Sluttid',
-                        time: state.form.endTime,
-                        onTap: () async {
-                          final picked = await showTimePicker(
-                            context: context,
-                            initialTime: TimeOfDay(
-                              hour: state.form.endTime.hour,
-                              minute: state.form.endTime.minute,
-                            ),
-                          );
-                          if (picked != null && context.mounted) {
-                            context.read<ActivityFormCubit>().setEndTime(
+                    controller: _titleController,
+                    onChanged: cubit.setTitle,
+                    textCapitalization: TextCapitalization.sentences,
+                  ),
+                  const SizedBox(height: 16),
+                  // Time toggle
+                  SwitchListTile(
+                    title: const Text('Angiv tidspunkt'),
+                    value: state.form.hasTime,
+                    onChanged: (_) => cubit.toggleHasTime(),
+                    contentPadding: EdgeInsets.zero,
+                  ),
+                  // Time pickers (only when enabled)
+                  if (state.form.hasTime) ...[
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: _TimePicker(
+                            label: 'Starttid',
+                            time: state.form.startTime,
+                            onTap: () async {
+                              final picked = await showTimePicker(
+                                context: context,
+                                initialTime: TimeOfDay(
+                                  hour: state.form.startTime.hour,
+                                  minute: state.form.startTime.minute,
+                                ),
+                              );
+                              if (picked != null && context.mounted) {
+                                cubit.setStartTime(
                                   (hour: picked.hour, minute: picked.minute),
                                 );
-                          }
-                        },
-                      ),
+                              }
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: _TimePicker(
+                            label: 'Sluttid',
+                            time: state.form.endTime,
+                            onTap: () async {
+                              final picked = await showTimePicker(
+                                context: context,
+                                initialTime: TimeOfDay(
+                                  hour: state.form.endTime.hour,
+                                  minute: state.form.endTime.minute,
+                                ),
+                              );
+                              if (picked != null && context.mounted) {
+                                cubit.setEndTime(
+                                  (hour: picked.hour, minute: picked.minute),
+                                );
+                              }
+                            },
+                          ),
+                        ),
+                      ],
                     ),
                   ],
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  'Piktogram',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                const PictogramSelector(),
-                const SizedBox(height: 24),
-                if (error != null)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 16),
-                    child: Text(
-                      error,
-                      style: TextStyle(color: context.colorScheme.error),
-                      textAlign: TextAlign.center,
-                    ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Piktogram',
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
-                ElevatedButton(
-                  onPressed: isSaving
-                      ? null
-                      : () => context.read<ActivityFormCubit>().save(),
-                  child: isSaving
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text(submitLabel),
-                ),
-              ],
+                  const SizedBox(height: 8),
+                  const PictogramSelector(),
+                  const SizedBox(height: 24),
+                  if (error != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 16),
+                      child: Text(
+                        error,
+                        style: TextStyle(color: context.colorScheme.error),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ElevatedButton(
+                    onPressed: isSaving
+                        ? null
+                        : () => cubit.save(),
+                    child: isSaving
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text(widget.submitLabel),
+                  ),
+                ],
+              ),
             ),
           );
         },

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -144,7 +144,9 @@ class _EmptyDay extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'Ingen aktiviteter for ${GirafDateUtils.dayName(selectedDate.weekday)}',
-            style: TextStyle(color: context.colorScheme.outline, fontSize: 16),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: context.colorScheme.outline,
+                ),
           ),
         ],
       ),

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -170,38 +170,48 @@ class _ActivityList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cubit = context.read<WeekplanCubit>();
-    return RefreshIndicator(
-      onRefresh: cubit.loadActivities,
-      child: ListView.builder(
-        padding: const EdgeInsets.only(top: 8, bottom: 80),
-        itemCount: activities.length,
-        itemBuilder: (context, index) {
-          final activity = activities[index];
-          final media = activity.pictogramId != null
-              ? pictogramMedia[activity.pictogramId!]
-              : null;
-          return ActivityListItem(
-            activity: activity,
-            imageUrl: media?.imageUrl,
-            soundUrl: media?.soundUrl,
-            onEdit: () async {
-              final dateStr =
-                  activity.date.toIso8601String().split('T').first;
-              final saved = await context.push<bool>(
-                '/weekplan/$citizenId/edit/${activity.activityId}'
-                '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
-                extra: activity,
-              );
-              if (saved == true && context.mounted) {
-                context.read<WeekplanCubit>().loadActivities();
-              }
-            },
-            onDelete: () => cubit.deleteActivity(activity.activityId),
-            onToggleStatus: () =>
-                cubit.toggleActivityStatus(activity.activityId),
-          );
-        },
-      ),
+    return ReorderableListView.builder(
+      padding: const EdgeInsets.only(top: 8, bottom: 80),
+      onReorder: cubit.reorderActivities,
+      proxyDecorator: (child, index, animation) {
+        return AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) => Material(
+            elevation: 4,
+            borderRadius: BorderRadius.circular(12),
+            child: child,
+          ),
+          child: child,
+        );
+      },
+      itemCount: activities.length,
+      itemBuilder: (context, index) {
+        final activity = activities[index];
+        final media = activity.pictogramId != null
+            ? pictogramMedia[activity.pictogramId!]
+            : null;
+        return ActivityListItem(
+          key: ValueKey(activity.activityId),
+          activity: activity,
+          imageUrl: media?.imageUrl,
+          soundUrl: media?.soundUrl,
+          onEdit: () async {
+            final dateStr =
+                activity.date.toIso8601String().split('T').first;
+            final saved = await context.push<bool>(
+              '/weekplan/$citizenId/edit/${activity.activityId}'
+              '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
+              extra: activity,
+            );
+            if (saved == true && context.mounted) {
+              context.read<WeekplanCubit>().loadActivities();
+            }
+          },
+          onDelete: () => cubit.deleteActivity(activity.activityId),
+          onToggleStatus: () =>
+              cubit.toggleActivityStatus(activity.activityId),
+        );
+      },
     );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -160,6 +160,52 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     }
   }
 
+  /// Optimistically reorder activities after a drag-and-drop.
+  Future<void> reorderActivities(int oldIndex, int newIndex) async {
+    final current = state;
+    if (current is! WeekplanLoaded) return;
+
+    // ReorderableListView adjusts index when moving down
+    final adjustedNew = oldIndex < newIndex ? newIndex - 1 : newIndex;
+    if (oldIndex == adjustedNew) return;
+
+    final backup = current.activities;
+    final reordered = List<Activity>.from(backup);
+    final item = reordered.removeAt(oldIndex);
+    reordered.insert(adjustedNew, item);
+
+    // Update sortOrder to match new positions
+    final withSortOrder = [
+      for (var i = 0; i < reordered.length; i++)
+        reordered[i].copyWith(sortOrder: i),
+    ];
+
+    emit(WeekplanLoaded(
+      selectedDate: current.selectedDate,
+      weekDates: current.weekDates,
+      activities: withSortOrder,
+      pictogramMedia: current.pictogramMedia,
+    ));
+
+    final result = await _activityRepository.reorderActivities(
+      id: subjectId,
+      isCitizen: isCitizen,
+      activities: withSortOrder,
+    );
+    switch (result) {
+      case Left(:final value):
+        _log.warning('Reorder rollback: ${value.message}');
+        emit(WeekplanLoaded(
+          selectedDate: current.selectedDate,
+          weekDates: current.weekDates,
+          activities: backup,
+          pictogramMedia: current.pictogramMedia,
+        ));
+      case Right():
+        break;
+    }
+  }
+
   /// Fetch image and sound URLs for pictograms in the given activities.
   Future<void> _fetchPictogramMedia(List<Activity> activities) async {
     final current = state;

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -29,6 +29,44 @@ class ActivityListItem extends StatefulWidget {
   State<ActivityListItem> createState() => _ActivityListItemState();
 }
 
+class _ActivityPictogram extends StatelessWidget {
+  final String? imageUrl;
+  final bool hasPictogram;
+
+  const _ActivityPictogram({
+    required this.imageUrl,
+    required this.hasPictogram,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 96,
+      height: 96,
+      decoration: BoxDecoration(
+        color: context.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: hasPictogram && imageUrl != null
+          ? Image.network(
+              imageUrl!,
+              fit: BoxFit.cover,
+              errorBuilder: (_, _, _) => Icon(
+                Icons.image,
+                size: 40,
+                color: context.colorScheme.onPrimaryContainer,
+              ),
+            )
+          : Icon(
+              hasPictogram ? Icons.image : Icons.event,
+              size: 40,
+              color: context.colorScheme.onPrimaryContainer,
+            ),
+    );
+  }
+}
+
 class _ActivityListItemState extends State<ActivityListItem> {
   final AudioPlayer _audioPlayer = AudioPlayer();
   late final StreamSubscription _onCompleteSubscription;
@@ -102,88 +140,67 @@ class _ActivityListItemState extends State<ActivityListItem> {
               padding: const EdgeInsets.all(12),
               child: Row(
                 children: [
-                  // Pictogram
-                  if (activity.pictogramId != null)
-                    Container(
-                      width: 56,
-                      height: 56,
-                      decoration: BoxDecoration(
-                        color: context.colorScheme.primary,
-                        borderRadius: BorderRadius.circular(28),
-                      ),
-                      clipBehavior: Clip.antiAlias,
-                      child: widget.imageUrl != null
-                          ? Image.network(
-                              widget.imageUrl!, // Guarded by != null check above.
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, _, _) => Icon(
-                                Icons.image,
-                                color: context.colorScheme.onPrimary,
-                              ),
-                            )
-                          : Icon(
-                              Icons.image,
-                              color: context.colorScheme.onPrimary,
-                            ),
-                    )
-                  else
-                    Container(
-                      width: 56,
-                      height: 56,
-                      decoration: BoxDecoration(
-                        color: context.colorScheme.primary,
-                        borderRadius: BorderRadius.circular(28),
-                      ),
-                      child: Icon(
-                        Icons.event,
-                        color: context.colorScheme.onPrimary,
-                      ),
-                    ),
-                  const SizedBox(width: 12),
-                  // Time and title
+                  // Pictogram — hero element
+                  _ActivityPictogram(
+                    imageUrl: widget.imageUrl,
+                    hasPictogram: activity.pictogramId != null,
+                  ),
+                  const SizedBox(width: 16),
+                  // Title and time
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        if (activity.title != null)
-                          Text(
-                            activity.title!,
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
+                        Text(
+                          activity.title ?? 'Unavngivet aktivitet',
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                color: activity.title != null
+                                    ? null
+                                    : context.colorScheme.outline,
+                              ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                         if (activity.startTime != null &&
-                            activity.endTime != null)
+                            activity.endTime != null) ...[
+                          const SizedBox(height: 4),
                           Text(
                             '${formatTimeValue(activity.startTime!)} - ${formatTimeValue(activity.endTime!)}',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: context.colorScheme.outline,
-                            ),
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: context.colorScheme.outline,
+                                ),
                           ),
+                        ],
                       ],
                     ),
                   ),
-                  // Sound playback button
-                  if (hasSound)
-                    ValueListenableBuilder<bool>(
-                      valueListenable: _isPlaying,
-                      builder: (_, isPlaying, _) => IconButton(
-                        onPressed: _togglePlayback,
-                        icon: Icon(
-                          isPlaying ? Icons.stop_circle : Icons.volume_up,
-                          color: context.girafColors.actionBlue,
-                        ),
-                        tooltip: isPlaying ? 'Stop' : 'Afspil lyd',
+                  // Sound + status column
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        activity.isCompleted
+                            ? Icons.check_circle
+                            : Icons.circle_outlined,
+                        color: activity.isCompleted
+                            ? context.girafColors.completedIndicator
+                            : context.colorScheme.outline,
+                        size: 28,
                       ),
-                    ),
-                  // Status indicator
-                  Icon(
-                    activity.isCompleted
-                        ? Icons.check_circle
-                        : Icons.circle_outlined,
-                    color: activity.isCompleted
-                        ? context.girafColors.completedIndicator
-                        : context.colorScheme.outline,
-                    size: 28,
+                      if (hasSound)
+                        ValueListenableBuilder<bool>(
+                          valueListenable: _isPlaying,
+                          builder: (_, isPlaying, _) => IconButton(
+                            onPressed: _togglePlayback,
+                            icon: Icon(
+                              isPlaying ? Icons.stop_circle : Icons.volume_up,
+                              color: context.girafColors.actionBlue,
+                            ),
+                            tooltip: isPlaying ? 'Stop' : 'Afspil lyd',
+                          ),
+                        ),
+                    ],
                   ),
                 ],
               ),

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -145,13 +145,20 @@ class _ActivityListItemState extends State<ActivityListItem> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '${formatTimeValue(activity.startTime)} - ${formatTimeValue(activity.endTime)}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: context.colorScheme.outline,
+                        if (activity.title != null)
+                          Text(
+                            activity.title!,
+                            style: Theme.of(context).textTheme.titleMedium,
                           ),
-                        ),
+                        if (activity.startTime != null &&
+                            activity.endTime != null)
+                          Text(
+                            '${formatTimeValue(activity.startTime!)} - ${formatTimeValue(activity.endTime!)}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              color: context.colorScheme.outline,
+                            ),
+                          ),
                       ],
                     ),
                   ),

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -48,21 +48,22 @@ class _ActivityPictogram extends StatelessWidget {
         borderRadius: BorderRadius.circular(12),
       ),
       clipBehavior: Clip.antiAlias,
-      child: hasPictogram && imageUrl != null
-          ? Image.network(
-              imageUrl!,
-              fit: BoxFit.cover,
-              errorBuilder: (_, _, _) => Icon(
-                Icons.image,
-                size: 40,
-                color: context.colorScheme.onPrimaryContainer,
-              ),
-            )
-          : Icon(
-              hasPictogram ? Icons.image : Icons.event,
+      child: switch (imageUrl) {
+        final url? when hasPictogram => Image.network(
+            url,
+            fit: BoxFit.cover,
+            errorBuilder: (_, _, _) => Icon(
+              Icons.image,
               size: 40,
               color: context.colorScheme.onPrimaryContainer,
             ),
+          ),
+        _ => Icon(
+            hasPictogram ? Icons.image : Icons.event,
+            size: 40,
+            color: context.colorScheme.onPrimaryContainer,
+          ),
+      },
     );
   }
 }
@@ -104,8 +105,8 @@ class _ActivityListItemState extends State<ActivityListItem> {
   @override
   Widget build(BuildContext context) {
     final activity = widget.activity;
-    // Null-check on left of && guarantees non-null on right.
-    final hasSound = widget.soundUrl != null && widget.soundUrl!.isNotEmpty;
+    final soundUrl = widget.soundUrl;
+    final hasSound = soundUrl != null && soundUrl.isNotEmpty;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/frontend/lib/shared/models/activity.dart
+++ b/frontend/lib/shared/models/activity.dart
@@ -11,10 +11,12 @@ abstract class Activity with _$Activity {
   const factory Activity({
     required int activityId,
     @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required DateTime date,
-    @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)
-    required TimeValue startTime,
-    @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)
-    required TimeValue endTime,
+    @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)
+    TimeValue? startTime,
+    @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)
+    TimeValue? endTime,
+    String? title,
+    @Default(0) int sortOrder,
     @Default(false) bool isCompleted,
     int? pictogramId,
   }) = _Activity;
@@ -25,14 +27,16 @@ abstract class Activity with _$Activity {
 
 final _log = Logger('Activity');
 
-TimeValue _timeFromJson(String s) {
+TimeValue? _nullableTimeFromJson(String? s) {
+  if (s == null) return null;
   final parsed = parseTimeValue(s);
   if (parsed == null) {
-    _log.warning('Unparseable time value: "$s", defaulting to 00:00');
+    _log.warning('Unparseable time value: "$s"');
   }
-  return parsed ?? (hour: 0, minute: 0);
+  return parsed;
 }
-String _timeToJson(TimeValue t) => formatTimeValueForApi(t);
+String? _nullableTimeToJson(TimeValue? t) =>
+    t != null ? formatTimeValueForApi(t) : null;
 
 DateTime _dateFromJson(String s) => DateTime.parse(s);
 String _dateToJson(DateTime d) => GirafDateUtils.formatQueryDate(d);

--- a/frontend/lib/shared/models/activity.freezed.dart
+++ b/frontend/lib/shared/models/activity.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Activity {
 
- int get activityId;@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime get date;@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue get startTime;@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue get endTime; bool get isCompleted; int? get pictogramId;
+ int get activityId;@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime get date;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get startTime;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get endTime; String? get title; int get sortOrder; bool get isCompleted; int? get pictogramId;
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ActivityCopyWith<Activity> get copyWith => _$ActivityCopyWithImpl<Activity>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,isCompleted,pictogramId);
+int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId);
 
 @override
 String toString() {
-  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, isCompleted: $isCompleted, pictogramId: $pictogramId)';
+  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ActivityCopyWith<$Res>  {
   factory $ActivityCopyWith(Activity value, $Res Function(Activity) _then) = _$ActivityCopyWithImpl;
 @useResult
 $Res call({
- int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue startTime,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue endTime, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId
 });
 
 
@@ -65,13 +65,15 @@ class _$ActivityCopyWithImpl<$Res>
 
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? activityId = null,Object? date = null,Object? startTime = null,Object? endTime = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
   return _then(_self.copyWith(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
-as DateTime,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as TimeValue,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as TimeValue,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as DateTime,startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as TimeValue?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as TimeValue?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
 as int?,
   ));
@@ -158,10 +160,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
   return orElse();
 
 }
@@ -179,10 +181,10 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)  $default,) {final _that = this;
 switch (_that) {
 case _Activity():
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +201,10 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson)  TimeValue endTime,  bool isCompleted,  int? pictogramId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)?  $default,) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
   return null;
 
 }
@@ -214,13 +216,15 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 @JsonSerializable()
 
 class _Activity implements Activity {
-  const _Activity({required this.activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required this.date, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) required this.startTime, @JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) required this.endTime, this.isCompleted = false, this.pictogramId});
+  const _Activity({required this.activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required this.date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.endTime, this.title, this.sortOrder = 0, this.isCompleted = false, this.pictogramId});
   factory _Activity.fromJson(Map<String, dynamic> json) => _$ActivityFromJson(json);
 
 @override final  int activityId;
 @override@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) final  DateTime date;
-@override@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) final  TimeValue startTime;
-@override@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) final  TimeValue endTime;
+@override@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) final  TimeValue? startTime;
+@override@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) final  TimeValue? endTime;
+@override final  String? title;
+@override@JsonKey() final  int sortOrder;
 @override@JsonKey() final  bool isCompleted;
 @override final  int? pictogramId;
 
@@ -237,16 +241,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,isCompleted,pictogramId);
+int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId);
 
 @override
 String toString() {
-  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, isCompleted: $isCompleted, pictogramId: $pictogramId)';
+  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId)';
 }
 
 
@@ -257,7 +261,7 @@ abstract mixin class _$ActivityCopyWith<$Res> implements $ActivityCopyWith<$Res>
   factory _$ActivityCopyWith(_Activity value, $Res Function(_Activity) _then) = __$ActivityCopyWithImpl;
 @override @useResult
 $Res call({
- int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue startTime,@JsonKey(fromJson: _timeFromJson, toJson: _timeToJson) TimeValue endTime, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId
 });
 
 
@@ -274,13 +278,15 @@ class __$ActivityCopyWithImpl<$Res>
 
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? activityId = null,Object? date = null,Object? startTime = null,Object? endTime = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
   return _then(_Activity(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
-as DateTime,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as TimeValue,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
-as TimeValue,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as DateTime,startTime: freezed == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as TimeValue?,endTime: freezed == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as TimeValue?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
 as int?,
   ));

--- a/frontend/lib/shared/models/activity.g.dart
+++ b/frontend/lib/shared/models/activity.g.dart
@@ -9,8 +9,10 @@ part of 'activity.dart';
 _Activity _$ActivityFromJson(Map<String, dynamic> json) => _Activity(
   activityId: (json['activityId'] as num).toInt(),
   date: _dateFromJson(json['date'] as String),
-  startTime: _timeFromJson(json['startTime'] as String),
-  endTime: _timeFromJson(json['endTime'] as String),
+  startTime: _nullableTimeFromJson(json['startTime'] as String?),
+  endTime: _nullableTimeFromJson(json['endTime'] as String?),
+  title: json['title'] as String?,
+  sortOrder: (json['sortOrder'] as num?)?.toInt() ?? 0,
   isCompleted: json['isCompleted'] as bool? ?? false,
   pictogramId: (json['pictogramId'] as num?)?.toInt(),
 );
@@ -18,8 +20,10 @@ _Activity _$ActivityFromJson(Map<String, dynamic> json) => _Activity(
 Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
   'activityId': instance.activityId,
   'date': _dateToJson(instance.date),
-  'startTime': _timeToJson(instance.startTime),
-  'endTime': _timeToJson(instance.endTime),
+  'startTime': _nullableTimeToJson(instance.startTime),
+  'endTime': _nullableTimeToJson(instance.endTime),
+  'title': instance.title,
+  'sortOrder': instance.sortOrder,
   'isCompleted': instance.isCompleted,
   'pictogramId': instance.pictogramId,
 };

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -92,6 +92,18 @@ class ActivityApiService implements TokenConsumer {
     await _dio.delete('/weekplan/activity/$activityId');
   }
 
+  // Reorder activities for a citizen or grade
+  Future<void> reorderActivities({
+    required int id,
+    required bool isCitizen,
+    required List<Map<String, dynamic>> items,
+  }) async {
+    final path = isCitizen
+        ? '/weekplan/reorder/$id'
+        : '/weekplan/reorder/grade/$id';
+    await _dio.put(path, data: items);
+  }
+
   // Toggle activity completion status
   Future<void> toggleActivityStatus(int activityId, {required bool isComplete}) async {
     await _dio.put(

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -307,19 +307,29 @@ void main() {
   });
 
   group('validate', () {
-    test('returns error when endTime <= startTime', () {
+    test('returns error when endTime <= startTime with time enabled', () {
       final cubit = buildCubit();
+      cubit.toggleHasTime();
       cubit.setStartTime(const (hour: 10, minute: 0));
       cubit.setEndTime(const (hour: 9, minute: 0));
       expect(cubit.validate(), 'Sluttid skal være efter starttid');
       cubit.close();
     });
 
-    test('returns error when endTime == startTime', () {
+    test('returns error when endTime == startTime with time enabled', () {
       final cubit = buildCubit();
+      cubit.toggleHasTime();
       cubit.setStartTime(const (hour: 10, minute: 0));
       cubit.setEndTime(const (hour: 10, minute: 0));
       expect(cubit.validate(), 'Sluttid skal være efter starttid');
+      cubit.close();
+    });
+
+    test('returns null when hasTime is false regardless of times', () {
+      final cubit = buildCubit();
+      cubit.setStartTime(const (hour: 10, minute: 0));
+      cubit.setEndTime(const (hour: 9, minute: 0));
+      expect(cubit.validate(), isNull);
       cubit.close();
     });
 
@@ -411,11 +421,18 @@ void main() {
       'emits ActivityFormReady with error and no Saving when validation fails',
       build: buildCubit,
       act: (cubit) async {
+        cubit.toggleHasTime();
         // Start time moved forward to 10:00, making it after the default end of 9:00
         cubit.setStartTime(const (hour: 10, minute: 0));
         await cubit.save();
       },
       expect: () => [
+        // toggleHasTime emits
+        isA<ActivityFormReady>().having(
+          (s) => s.form.hasTime,
+          'hasTime',
+          true,
+        ),
         // setStartTime emits
         isA<ActivityFormReady>().having(
           (s) => s.form.startTime,

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -35,7 +35,7 @@ void main() {
   }
 
   group('ActivityFormView', () {
-    testWidgets('shows time pickers and submit button in ready state',
+    testWidgets('shows title field and submit button in ready state',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: ActivityFormData(date: testDate),
@@ -43,9 +43,31 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
+      expect(find.text('Titel'), findsOneWidget);
+      expect(find.text('Angiv tidspunkt'), findsOneWidget);
+      expect(find.text('Tilføj'), findsOneWidget);
+    });
+
+    testWidgets('shows time pickers when hasTime is enabled', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: testDate, hasTime: true),
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
       expect(find.text('Starttid'), findsOneWidget);
       expect(find.text('Sluttid'), findsOneWidget);
-      expect(find.text('Tilføj'), findsOneWidget);
+    });
+
+    testWidgets('hides time pickers when hasTime is disabled', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: testDate),
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('Starttid'), findsNothing);
+      expect(find.text('Sluttid'), findsNothing);
     });
 
     testWidgets('shows error text in ready state with error', (tester) async {
@@ -72,7 +94,8 @@ void main() {
       expect(find.text('Tilføj'), findsNothing);
 
       // The ElevatedButton should be disabled
-      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton).first);
+      final button =
+          tester.widget<ElevatedButton>(find.byType(ElevatedButton).first);
       expect(button.onPressed, isNull);
     });
 
@@ -83,7 +106,10 @@ void main() {
       when(() => mockCubit.save()).thenAnswer((_) async => true);
 
       await tester.pumpWidget(buildSubject());
+      await tester.ensureVisible(find.text('Tilføj'));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Tilføj'));
+      await tester.pump();
 
       verify(() => mockCubit.save()).called(1);
     });


### PR DESCRIPTION
## Summary
Complete UX overhaul of the weekplanner activity cards to be child-friendly:

- **Activity titles** — activities now have an optional name/label (e.g. "Morgenmad", "Samling")
- **Optional time** — time slots are no longer required; toggle on/off in the form
- **Pictogram-first design** — pictogram enlarged from 56x56 to 96x96 rounded square, title prominent, time secondary
- **Drag-to-reorder** — activities can be reordered via long-press drag
- **Sound/TTS ready** — playback button shows when pictogram has audio

### Backend changes
- `Title` (varchar 200), `SortOrder` (int) added to Activity entity
- `StartTime`/`EndTime` made nullable
- New reorder endpoints: `PUT /weekplan/reorder/{citizenId}`, `PUT /weekplan/reorder/grade/{gradeId}`
- Activities now sorted by SortOrder, then StartTime
- Grade endpoint returns empty list instead of 404 for empty days (fixes #45)
- Auto-assigns SortOrder on create
- EF Core migration included

### Frontend changes
- Activity freezed model updated with `title`, `sortOrder`, nullable times
- Form: title TextField, "Angiv tidspunkt" toggle, IgnorePointer during save (fixes #46)
- Card: 96x96 pictogram, prominent title, secondary time, extracted `_ActivityPictogram` widget
- ReorderableListView with optimistic reorder + rollback
- Reorder API service + repository method

Closes #44, closes #45, closes #46

## Test plan
- [x] Backend: 54 integration tests pass (7 new)
- [x] Frontend: 195 Flutter tests pass (3 new)
- [x] `dart analyze` — zero issues
- [x] `dotnet build` — zero warnings
- [ ] Deploy to Strato, run migration, test full flow
- [ ] Create activity with title only (no time) — verify card shows title
- [ ] Create activity with pictogram + TTS — verify sound plays
- [ ] Drag activities to reorder — verify order persists after reload