### PR TITLE
fix: pictogram name is the activity title, tap card to play sound

### DIFF
--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -55,10 +55,6 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   // ── Form field setters ────────────────────────────────────
 
-  void setTitle(String title) {
-    _emitReady(form: state.form.copyWith(title: title));
-  }
-
   void toggleHasTime() {
     _emitReady(form: state.form.copyWith(hasTime: !state.form.hasTime));
   }
@@ -106,6 +102,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
   void selectPictogram(Pictogram pictogram) {
     _emitReady(
       selection: PictogramSelection(id: pictogram.id, pictogram: pictogram),
+      form: state.form.copyWith(title: pictogram.name),
     );
   }
 
@@ -165,6 +162,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         _emitReady(
           creation: state.creation.copyWith(isCreating: false),
           selection: PictogramSelection(id: value.id, pictogram: value),
+          form: state.form.copyWith(title: value.name),
         );
         return true;
     }
@@ -200,6 +198,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         _emitReady(
           creation: state.creation.copyWith(isCreating: false),
           selection: PictogramSelection(id: value.id, pictogram: value),
+          form: state.form.copyWith(title: value.name),
         );
         return true;
     }
@@ -209,6 +208,9 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Validate the form and return an error message, or null if valid.
   String? validate() {
+    if (state.selection.id == null) {
+      return 'Vælg et piktogram';
+    }
     if (state.form.hasTime) {
       final startMinutes =
           state.form.startTime.hour * 60 + state.form.startTime.minute;
@@ -243,8 +245,8 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         'startTime': formatTimeValueForApi(s.form.startTime),
       if (s.form.hasTime)
         'endTime': formatTimeValueForApi(s.form.endTime),
-      if (s.form.title.isNotEmpty) 'title': s.form.title,
-      if (s.selection.id != null) 'pictogramId': s.selection.id,
+      'title': s.form.title,
+      'pictogramId': s.selection.id,
     };
 
     final Either<ActivityFailure, Activity> result;

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -136,7 +136,8 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Upload a local image as a new pictogram and select it.
   Future<bool> uploadPictogramFromFile() async {
-    if (state.creation.imageFile == null || state.creation.name.isEmpty) {
+    final imageFile = state.creation.imageFile;
+    if (imageFile == null || state.creation.name.isEmpty) {
       _emitReady(error: 'Angiv navn og vælg et billede');
       return false;
     }
@@ -145,7 +146,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
     final result = await _pictogramRepository.uploadPictogram(
       name: state.creation.name,
-      imageFile: state.creation.imageFile!,
+      imageFile: imageFile,
       soundFile: state.creation.soundFile,
       organizationId: organizationId,
       generateSound: state.creation.generateSound,

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -8,7 +8,7 @@ import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.d
 import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_selector.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
-class ActivityFormView extends StatefulWidget {
+class ActivityFormView extends StatelessWidget {
   const ActivityFormView({
     super.key,
     required this.title,
@@ -19,30 +19,10 @@ class ActivityFormView extends StatefulWidget {
   final String submitLabel;
 
   @override
-  State<ActivityFormView> createState() => _ActivityFormViewState();
-}
-
-class _ActivityFormViewState extends State<ActivityFormView> {
-  late final TextEditingController _titleController;
-
-  @override
-  void initState() {
-    super.initState();
-    final cubit = context.read<ActivityFormCubit>();
-    _titleController = TextEditingController(text: cubit.state.form.title);
-  }
-
-  @override
-  void dispose() {
-    _titleController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: Text(title),
       ),
       body: BlocConsumer<ActivityFormCubit, ActivityFormState>(
         listener: (context, state) {
@@ -61,18 +41,14 @@ class _ActivityFormViewState extends State<ActivityFormView> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  // Title field
-                  TextField(
-                    decoration: const InputDecoration(
-                      labelText: 'Titel',
-                      hintText: 'F.eks. Morgenmad, Samling, Frikvarter',
-                      prefixIcon: Icon(Icons.label_outline),
-                    ),
-                    controller: _titleController,
-                    onChanged: cubit.setTitle,
-                    textCapitalization: TextCapitalization.sentences,
+                  // Pictogram selector (required)
+                  Text(
+                    'Piktogram',
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 8),
+                  const PictogramSelector(),
+                  const SizedBox(height: 24),
                   // Time toggle
                   SwitchListTile(
                     title: const Text('Angiv tidspunkt'),
@@ -130,13 +106,6 @@ class _ActivityFormViewState extends State<ActivityFormView> {
                     ),
                   ],
                   const SizedBox(height: 24),
-                  Text(
-                    'Piktogram',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  const PictogramSelector(),
-                  const SizedBox(height: 24),
                   if (error != null)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 16),
@@ -156,7 +125,7 @@ class _ActivityFormViewState extends State<ActivityFormView> {
                             width: 20,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Text(widget.submitLabel),
+                        : Text(submitLabel),
                   ),
                 ],
               ),

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -29,45 +29,6 @@ class ActivityListItem extends StatefulWidget {
   State<ActivityListItem> createState() => _ActivityListItemState();
 }
 
-class _ActivityPictogram extends StatelessWidget {
-  final String? imageUrl;
-  final bool hasPictogram;
-
-  const _ActivityPictogram({
-    required this.imageUrl,
-    required this.hasPictogram,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 96,
-      height: 96,
-      decoration: BoxDecoration(
-        color: context.colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: switch (imageUrl) {
-        final url? when hasPictogram => Image.network(
-            url,
-            fit: BoxFit.cover,
-            errorBuilder: (_, _, _) => Icon(
-              Icons.image,
-              size: 40,
-              color: context.colorScheme.onPrimaryContainer,
-            ),
-          ),
-        _ => Icon(
-            hasPictogram ? Icons.image : Icons.event,
-            size: 40,
-            color: context.colorScheme.onPrimaryContainer,
-          ),
-      },
-    );
-  }
-}
-
 class _ActivityListItemState extends State<ActivityListItem> {
   final AudioPlayer _audioPlayer = AudioPlayer();
   late final StreamSubscription _onCompleteSubscription;
@@ -163,16 +124,16 @@ class _ActivityListItemState extends State<ActivityListItem> {
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        if (activity.startTime != null &&
-                            activity.endTime != null) ...[
-                          const SizedBox(height: 4),
-                          Text(
-                            '${formatTimeValue(activity.startTime!)} - ${formatTimeValue(activity.endTime!)}',
-                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: context.colorScheme.outline,
-                                ),
-                          ),
-                        ],
+                        if (activity.startTime case final start?)
+                          if (activity.endTime case final end?) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              '${formatTimeValue(start)} - ${formatTimeValue(end)}',
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: context.colorScheme.outline,
+                                  ),
+                            ),
+                          ],
                       ],
                     ),
                   ),
@@ -196,6 +157,45 @@ class _ActivityListItemState extends State<ActivityListItem> {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ActivityPictogram extends StatelessWidget {
+  final String? imageUrl;
+  final bool hasPictogram;
+
+  const _ActivityPictogram({
+    required this.imageUrl,
+    required this.hasPictogram,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 96,
+      height: 96,
+      decoration: BoxDecoration(
+        color: context.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: switch (imageUrl) {
+        final url? when hasPictogram => Image.network(
+            url,
+            fit: BoxFit.cover,
+            errorBuilder: (_, _, _) => Icon(
+              Icons.image,
+              size: 40,
+              color: context.colorScheme.onPrimaryContainer,
+            ),
+          ),
+        _ => Icon(
+            hasPictogram ? Icons.image : Icons.event,
+            size: 40,
+            color: context.colorScheme.onPrimaryContainer,
+          ),
+      },
     );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -135,7 +135,7 @@ class _ActivityListItemState extends State<ActivityListItem> {
               ? context.girafColors.completedBackground
               : context.girafColors.pendingBackground,
           child: InkWell(
-            onTap: widget.onToggleStatus,
+            onTap: hasSound ? _togglePlayback : null,
             borderRadius: BorderRadius.circular(12),
             child: Padding(
               padding: const EdgeInsets.all(12),
@@ -176,32 +176,19 @@ class _ActivityListItemState extends State<ActivityListItem> {
                       ],
                     ),
                   ),
-                  // Sound + status column
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        activity.isCompleted
-                            ? Icons.check_circle
-                            : Icons.circle_outlined,
-                        color: activity.isCompleted
-                            ? context.girafColors.completedIndicator
-                            : context.colorScheme.outline,
-                        size: 28,
-                      ),
-                      if (hasSound)
-                        ValueListenableBuilder<bool>(
-                          valueListenable: _isPlaying,
-                          builder: (_, isPlaying, _) => IconButton(
-                            onPressed: _togglePlayback,
-                            icon: Icon(
-                              isPlaying ? Icons.stop_circle : Icons.volume_up,
-                              color: context.girafColors.actionBlue,
-                            ),
-                            tooltip: isPlaying ? 'Stop' : 'Afspil lyd',
-                          ),
-                        ),
-                    ],
+                  // Completion toggle
+                  IconButton(
+                    onPressed: widget.onToggleStatus,
+                    icon: Icon(
+                      activity.isCompleted
+                          ? Icons.check_circle
+                          : Icons.circle_outlined,
+                      color: activity.isCompleted
+                          ? context.girafColors.completedIndicator
+                          : context.colorScheme.outline,
+                      size: 28,
+                    ),
+                    tooltip: activity.isCompleted ? 'Ikke færdig' : 'Færdig',
                   ),
                 ],
               ),

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -307,8 +307,15 @@ void main() {
   });
 
   group('validate', () {
+    test('returns error when no pictogram is selected', () {
+      final cubit = buildCubit();
+      expect(cubit.validate(), 'Vælg et piktogram');
+      cubit.close();
+    });
+
     test('returns error when endTime <= startTime with time enabled', () {
       final cubit = buildCubit();
+      cubit.selectPictogram(testPictogram);
       cubit.toggleHasTime();
       cubit.setStartTime(const (hour: 10, minute: 0));
       cubit.setEndTime(const (hour: 9, minute: 0));
@@ -318,6 +325,7 @@ void main() {
 
     test('returns error when endTime == startTime with time enabled', () {
       final cubit = buildCubit();
+      cubit.selectPictogram(testPictogram);
       cubit.toggleHasTime();
       cubit.setStartTime(const (hour: 10, minute: 0));
       cubit.setEndTime(const (hour: 10, minute: 0));
@@ -327,6 +335,7 @@ void main() {
 
     test('returns null when hasTime is false regardless of times', () {
       final cubit = buildCubit();
+      cubit.selectPictogram(testPictogram);
       cubit.setStartTime(const (hour: 10, minute: 0));
       cubit.setEndTime(const (hour: 9, minute: 0));
       expect(cubit.validate(), isNull);
@@ -335,6 +344,7 @@ void main() {
 
     test('returns null when times are valid', () {
       final cubit = buildCubit();
+      cubit.selectPictogram(testPictogram);
       cubit.setStartTime(const (hour: 8, minute: 0));
       cubit.setEndTime(const (hour: 9, minute: 0));
       expect(cubit.validate(), isNull);
@@ -355,8 +365,12 @@ void main() {
         ).thenAnswer((_) async => Right(testActivity));
       },
       build: buildCubit,
-      act: (cubit) => cubit.save(),
+      act: (cubit) {
+        cubit.selectPictogram(testPictogram);
+        return cubit.save();
+      },
       expect: () => [
+        isA<ActivityFormReady>(), // selectPictogram
         isA<ActivityFormSaving>(),
         isA<ActivityFormSaved>(),
       ],
@@ -383,8 +397,12 @@ void main() {
         ).thenAnswer((_) async => const Left(CreateActivityFailure()));
       },
       build: buildCubit,
-      act: (cubit) => cubit.save(),
+      act: (cubit) {
+        cubit.selectPictogram(testPictogram);
+        return cubit.save();
+      },
       expect: () => [
+        isA<ActivityFormReady>(), // selectPictogram
         isA<ActivityFormSaving>(),
         isA<ActivityFormReady>().having(
           (s) => s.error,
@@ -405,8 +423,12 @@ void main() {
         ).thenAnswer((_) async => Right(testActivity));
       },
       build: () => buildCubit(existingActivity: testActivity),
-      act: (cubit) => cubit.save(),
+      act: (cubit) {
+        cubit.selectPictogram(testPictogram);
+        return cubit.save();
+      },
       expect: () => [
+        isA<ActivityFormReady>(), // selectPictogram
         isA<ActivityFormSaving>(),
         isA<ActivityFormSaved>(),
       ],
@@ -421,12 +443,15 @@ void main() {
       'emits ActivityFormReady with error and no Saving when validation fails',
       build: buildCubit,
       act: (cubit) async {
+        cubit.selectPictogram(testPictogram);
         cubit.toggleHasTime();
         // Start time moved forward to 10:00, making it after the default end of 9:00
         cubit.setStartTime(const (hour: 10, minute: 0));
         await cubit.save();
       },
       expect: () => [
+        // selectPictogram emits
+        isA<ActivityFormReady>(),
         // toggleHasTime emits
         isA<ActivityFormReady>().having(
           (s) => s.form.hasTime,

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -35,7 +35,7 @@ void main() {
   }
 
   group('ActivityFormView', () {
-    testWidgets('shows title field and submit button in ready state',
+    testWidgets('shows pictogram label and submit button in ready state',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: ActivityFormData(date: testDate),
@@ -43,7 +43,7 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      expect(find.text('Titel'), findsOneWidget);
+      expect(find.text('Piktogram'), findsOneWidget);
       expect(find.text('Angiv tidspunkt'), findsOneWidget);
       expect(find.text('Tilføj'), findsOneWidget);
     });

--- a/frontend/test/features/weekplan/activity_list_item_test.dart
+++ b/frontend/test/features/weekplan/activity_list_item_test.dart
@@ -66,24 +66,25 @@ void main() {
       expect(find.byIcon(Icons.circle_outlined), findsOneWidget);
     });
 
-    testWidgets('tapping the card calls onToggleStatus', (tester) async {
+    testWidgets('tapping the checkbox icon calls onToggleStatus',
+        (tester) async {
       var callCount = 0;
 
       await tester.pumpWidget(buildSubject(onToggleStatus: () => callCount++));
 
-      await tester.tap(find.byType(InkWell).first);
+      await tester.tap(find.byTooltip('Færdig'));
       await tester.pump();
 
       expect(callCount, 1);
     });
 
-    testWidgets('sound button is visible when soundUrl is provided',
-        (tester) async {
+    testWidgets('card is tappable when soundUrl is provided', (tester) async {
       await tester.pumpWidget(
         buildSubject(soundUrl: 'http://test.mp3'),
       );
 
-      expect(find.byIcon(Icons.volume_up), findsOneWidget);
+      final inkWell = tester.widget<InkWell>(find.byType(InkWell).first);
+      expect(inkWell.onTap, isNotNull);
     });
 
     testWidgets('sound button is hidden when soundUrl is null', (tester) async {


### PR DESCRIPTION
## Summary
- Activity title = pictogram name, always. No separate title field.
- Pictogram is required — can't create an activity without one.
- Tapping the activity card plays the pictogram's sound/TTS.
- Completion toggle is now a dedicated checkbox icon button.

## Why
The previous design had a separate title field and the pictogram name as two different things. For non-verbal children, the pictogram IS the activity — there's no reason for a separate title. Also, tapping the card should say the activity name (TTS), not toggle completion.

## Changes
- `activity_form_cubit.dart`: removed `setTitle()`, `selectPictogram()` auto-fills title from pictogram name, `validate()` requires pictogram
- `activity_form_view.dart`: removed title TextField, pictogram selector first, back to StatelessWidget
- `activity_list_item.dart`: card tap plays sound, completion toggle is IconButton
- Updated all tests (196 pass)

## Test plan
- [x] `dart analyze` — zero issues
- [x] `flutter test` — 196 tests pass
- [ ] Create activity — must select pictogram first, title auto-fills
- [ ] Tap activity card — plays sound if available
- [ ] Tap checkbox — toggles completion