### PR TITLE
fix: log actual server error responses in repositories

### DIFF
--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
@@ -19,6 +20,16 @@ class ActivityRepositoryImpl implements ActivityRepository {
   ActivityRepositoryImpl({required ActivityApiService apiService})
       : _apiService = apiService;
 
+  /// Log an error with the server response body when available.
+  void _logError(String message, Object error, StackTrace stackTrace) {
+    if (error is DioException) {
+      final responseData = error.response?.data;
+      _log.severe('$message — server: $responseData', error, stackTrace);
+    } else {
+      _log.severe(message, error, stackTrace);
+    }
+  }
+
   @override
   Future<Either<ActivityFailure, List<Activity>>> fetchActivities({
     required int id,
@@ -32,7 +43,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           : await _apiService.fetchActivitiesByGrade(id, dateStr);
       return Right(activities);
     } catch (e, stackTrace) {
-      _log.severe('Failed to fetch activities', e, stackTrace);
+      _logError('Failed to fetch activities', e, stackTrace);
       return Left(const FetchActivitiesFailure());
     }
   }
@@ -49,7 +60,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           : await _apiService.createActivityForGrade(id, data);
       return Right(activity);
     } catch (e, stackTrace) {
-      _log.severe('Failed to create activity', e, stackTrace);
+      _logError('Failed to create activity', e, stackTrace);
       return Left(const CreateActivityFailure());
     }
   }
@@ -63,7 +74,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       final updated = await _apiService.updateActivity(activityId, data);
       return Right(updated);
     } catch (e, stackTrace) {
-      _log.severe('Failed to update activity', e, stackTrace);
+      _logError('Failed to update activity', e, stackTrace);
       return Left(const UpdateActivityFailure());
     }
   }
@@ -74,7 +85,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       await _apiService.deleteActivity(activityId);
       return const Right(unit);
     } catch (e, stackTrace) {
-      _log.severe('Failed to delete activity', e, stackTrace);
+      _logError('Failed to delete activity', e, stackTrace);
       return Left(const DeleteActivityFailure());
     }
   }
@@ -89,7 +100,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           isComplete: isComplete);
       return const Right(unit);
     } catch (e, stackTrace) {
-      _log.severe('Failed to toggle activity status', e, stackTrace);
+      _logError('Failed to toggle activity status', e, stackTrace);
       return Left(const ToggleStatusFailure());
     }
   }
@@ -116,7 +127,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       );
       return const Right(unit);
     } catch (e, stackTrace) {
-      _log.severe('Failed to reorder activities', e, stackTrace);
+      _logError('Failed to reorder activities', e, stackTrace);
       return Left(const ReorderActivitiesFailure());
     }
   }

--- a/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
@@ -28,7 +28,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       final response = await _apiService.searchPictograms(query: query);
       return Right(response.items);
     } catch (e, stackTrace) {
-      _log.severe('Failed to search pictograms', e, stackTrace);
+      _logError('Failed to search pictograms', e, stackTrace);
       return Left(const SearchPictogramsFailure());
     }
   }
@@ -39,7 +39,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       final pictogram = await _apiService.fetchPictogram(id);
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _log.severe('Failed to fetch pictogram $id', e, stackTrace);
+      _logError('Failed to fetch pictogram $id', e, stackTrace);
       return Left(const FetchPictogramFailure());
     }
   }
@@ -62,7 +62,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       );
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _log.severe('Failed to create pictogram', e, stackTrace);
+      _logError('Failed to create pictogram', e, stackTrace);
       return Left(const CreatePictogramFailure());
     }
   }
@@ -85,8 +85,18 @@ class PictogramRepositoryImpl implements PictogramRepository {
       );
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _log.severe('Failed to upload pictogram', e, stackTrace);
+      _logError('Failed to upload pictogram', e, stackTrace);
       return Left(const CreatePictogramFailure());
+    }
+  }
+
+  /// Log an error with the server response body when available.
+  void _logError(String message, Object error, StackTrace stackTrace) {
+    if (error is DioException) {
+      final responseData = error.response?.data;
+      _log.severe('$message — server: $responseData', error, stackTrace);
+    } else {
+      _log.severe(message, error, stackTrace);
     }
   }
 


### PR DESCRIPTION
## Summary
Repository catch blocks now log the server response body from DioException, not just the generic exception message.

Before: `Failed to upload pictogram: DioException [bad response]: ...`
After: `Failed to upload pictogram — server: {detail: File size must not exceed 5MB.}`

## Why
Without this, debugging API errors is pure guesswork. We had a 422 from the pictogram upload and no way to see the actual validation error.

## Changes
- `activity_repository.dart`: add `_logError()` helper, use for all catch blocks
- `pictogram_repository.dart`: same pattern