### PR TITLE
refactor: extract logServerError to shared utility

### DIFF
--- a/frontend/lib/core/logging.dart
+++ b/frontend/lib/core/logging.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:logging/logging.dart';
+
+/// Log an error, extracting the server response body from [DioException]
+/// when available. Falls back to standard [Logger.severe] for other errors.
+void logServerError(
+  Logger logger,
+  String message,
+  Object error,
+  StackTrace stackTrace,
+) {
+  if (error is DioException) {
+    final responseData = error.response?.data;
+    logger.severe('$message — server: $responseData', error, stackTrace);
+  } else {
+    logger.severe(message, error, stackTrace);
+  }
+}

--- a/frontend/lib/features/auth/data/repositories/auth_repository.dart
+++ b/frontend/lib/features/auth/data/repositories/auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/auth_failure.dart';
+import 'package:weekplanner/core/logging.dart';
 import 'package:weekplanner/features/auth/domain/repositories/auth_repository.dart';
 import 'package:weekplanner/shared/models/auth_tokens.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
@@ -31,7 +32,7 @@ class AuthRepositoryImpl implements AuthRepository {
     } on DioException catch (e, stackTrace) {
       return Left(_mapDioError(e, stackTrace));
     } catch (e, stackTrace) {
-      _log.severe('Unexpected login error', e, stackTrace);
+      logServerError(_log, 'Unexpected login error', e, stackTrace);
       return Left(const UnexpectedFailure());
     }
   }
@@ -88,7 +89,7 @@ class AuthRepositoryImpl implements AuthRepository {
       await _authService.logout();
       return const Right(unit);
     } catch (e, stackTrace) {
-      _log.severe('Logout failed', e, stackTrace);
+      logServerError(_log, 'Logout failed', e, stackTrace);
       return Left(const UnexpectedFailure());
     }
   }
@@ -123,7 +124,7 @@ class AuthRepositoryImpl implements AuthRepository {
       _log.warning('Login failed: invalid credentials', e, stackTrace);
       return const InvalidCredentialsFailure();
     }
-    _log.severe('Login failed: server error', e, stackTrace);
+    logServerError(_log, 'Login failed: server error', e, stackTrace);
     return const ServerFailure();
   }
 }

--- a/frontend/lib/features/organisation_picker/data/repositories/organisation_repository.dart
+++ b/frontend/lib/features/organisation_picker/data/repositories/organisation_repository.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/organisation_failure.dart';
+import 'package:weekplanner/core/logging.dart';
 import 'package:weekplanner/features/organisation_picker/domain/repositories/organisation_repository.dart';
 import 'package:weekplanner/shared/models/citizen.dart';
 import 'package:weekplanner/shared/models/grade.dart';
@@ -27,7 +28,7 @@ class OrganisationRepositoryImpl implements OrganisationRepository {
       final response = await _apiService.fetchOrganisations();
       return Right(response.items);
     } catch (e, stackTrace) {
-      _log.severe('Failed to fetch organisations', e, stackTrace);
+      logServerError(_log,'Failed to fetch organisations', e, stackTrace);
       return Left(const FetchOrganisationsFailure());
     }
   }
@@ -44,7 +45,7 @@ class OrganisationRepositoryImpl implements OrganisationRepository {
         (citizens: citizenResponse.items, grades: gradeResponse.items),
       );
     } catch (e, stackTrace) {
-      _log.severe('Failed to fetch citizens and grades', e, stackTrace);
+      logServerError(_log,'Failed to fetch citizens and grades', e, stackTrace);
       return Left(const FetchCitizensFailure());
     }
   }

--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -1,8 +1,8 @@
-import 'package:dio/dio.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/activity_failure.dart';
+import 'package:weekplanner/core/logging.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/activity_repository.dart';
 import 'package:weekplanner/shared/models/activity.dart';
 import 'package:weekplanner/shared/services/activity_api_service.dart';
@@ -20,16 +20,6 @@ class ActivityRepositoryImpl implements ActivityRepository {
   ActivityRepositoryImpl({required ActivityApiService apiService})
       : _apiService = apiService;
 
-  /// Log an error with the server response body when available.
-  void _logError(String message, Object error, StackTrace stackTrace) {
-    if (error is DioException) {
-      final responseData = error.response?.data;
-      _log.severe('$message — server: $responseData', error, stackTrace);
-    } else {
-      _log.severe(message, error, stackTrace);
-    }
-  }
-
   @override
   Future<Either<ActivityFailure, List<Activity>>> fetchActivities({
     required int id,
@@ -43,7 +33,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           : await _apiService.fetchActivitiesByGrade(id, dateStr);
       return Right(activities);
     } catch (e, stackTrace) {
-      _logError('Failed to fetch activities', e, stackTrace);
+      logServerError(_log,'Failed to fetch activities', e, stackTrace);
       return Left(const FetchActivitiesFailure());
     }
   }
@@ -60,7 +50,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           : await _apiService.createActivityForGrade(id, data);
       return Right(activity);
     } catch (e, stackTrace) {
-      _logError('Failed to create activity', e, stackTrace);
+      logServerError(_log,'Failed to create activity', e, stackTrace);
       return Left(const CreateActivityFailure());
     }
   }
@@ -74,7 +64,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       final updated = await _apiService.updateActivity(activityId, data);
       return Right(updated);
     } catch (e, stackTrace) {
-      _logError('Failed to update activity', e, stackTrace);
+      logServerError(_log,'Failed to update activity', e, stackTrace);
       return Left(const UpdateActivityFailure());
     }
   }
@@ -85,7 +75,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       await _apiService.deleteActivity(activityId);
       return const Right(unit);
     } catch (e, stackTrace) {
-      _logError('Failed to delete activity', e, stackTrace);
+      logServerError(_log,'Failed to delete activity', e, stackTrace);
       return Left(const DeleteActivityFailure());
     }
   }
@@ -100,7 +90,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
           isComplete: isComplete);
       return const Right(unit);
     } catch (e, stackTrace) {
-      _logError('Failed to toggle activity status', e, stackTrace);
+      logServerError(_log,'Failed to toggle activity status', e, stackTrace);
       return Left(const ToggleStatusFailure());
     }
   }
@@ -127,7 +117,7 @@ class ActivityRepositoryImpl implements ActivityRepository {
       );
       return const Right(unit);
     } catch (e, stackTrace) {
-      _logError('Failed to reorder activities', e, stackTrace);
+      logServerError(_log,'Failed to reorder activities', e, stackTrace);
       return Left(const ReorderActivitiesFailure());
     }
   }

--- a/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/pictogram_repository.dart
@@ -3,6 +3,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:logging/logging.dart';
 
 import 'package:weekplanner/core/errors/pictogram_failure.dart';
+import 'package:weekplanner/core/logging.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
 import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
@@ -28,7 +29,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       final response = await _apiService.searchPictograms(query: query);
       return Right(response.items);
     } catch (e, stackTrace) {
-      _logError('Failed to search pictograms', e, stackTrace);
+      logServerError(_log,'Failed to search pictograms', e, stackTrace);
       return Left(const SearchPictogramsFailure());
     }
   }
@@ -39,7 +40,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       final pictogram = await _apiService.fetchPictogram(id);
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _logError('Failed to fetch pictogram $id', e, stackTrace);
+      logServerError(_log,'Failed to fetch pictogram $id', e, stackTrace);
       return Left(const FetchPictogramFailure());
     }
   }
@@ -62,7 +63,7 @@ class PictogramRepositoryImpl implements PictogramRepository {
       );
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _logError('Failed to create pictogram', e, stackTrace);
+      logServerError(_log,'Failed to create pictogram', e, stackTrace);
       return Left(const CreatePictogramFailure());
     }
   }
@@ -85,18 +86,8 @@ class PictogramRepositoryImpl implements PictogramRepository {
       );
       return Right(pictogram);
     } catch (e, stackTrace) {
-      _logError('Failed to upload pictogram', e, stackTrace);
+      logServerError(_log,'Failed to upload pictogram', e, stackTrace);
       return Left(const CreatePictogramFailure());
-    }
-  }
-
-  /// Log an error with the server response body when available.
-  void _logError(String message, Object error, StackTrace stackTrace) {
-    if (error is DioException) {
-      final responseData = error.response?.data;
-      _log.severe('$message — server: $responseData', error, stackTrace);
-    } else {
-      _log.severe(message, error, stackTrace);
     }
   }
 

--- a/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
+++ b/frontend/lib/shared/interceptors/token_refresh_interceptor.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logging/logging.dart';
+import 'package:weekplanner/core/logging.dart';
 import 'package:weekplanner/shared/services/auth_service.dart';
 
 final _log = Logger('TokenRefreshInterceptor');
@@ -110,7 +111,7 @@ class TokenRefreshInterceptor extends Interceptor {
       onRefreshFailed?.call();
       return handler.next(err);
     } catch (e, stackTrace) {
-      _log.severe('Unexpected error during token refresh', e, stackTrace);
+      logServerError(_log, 'Unexpected error during token refresh', e, stackTrace);
       _refreshCompleter!.complete(null);
       onRefreshFailed?.call();
       return handler.next(err);


### PR DESCRIPTION
## Summary
Follow-up to #49. Extracts the `_logError` helper into a shared `logServerError()` function in `core/logging.dart` and applies it to all repositories and the token refresh interceptor.

## Changes
- New `core/logging.dart` with `logServerError(logger, message, error, stackTrace)`
- Replaced duplicated `_logError` in activity and pictogram repositories
- Applied to auth repository, organisation repository, token refresh interceptor
- 196 tests pass, zero analyze issues