### PR TITLE
feat: add title and date fields to activity form

### DIFF
--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -55,6 +55,14 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   // ── Form field setters ────────────────────────────────────
 
+  void setTitle(String title) {
+    _emitReady(form: state.form.copyWith(title: title));
+  }
+
+  void setDate(DateTime date) {
+    _emitReady(form: state.form.copyWith(date: date));
+  }
+
   void toggleHasTime() {
     _emitReady(form: state.form.copyWith(hasTime: !state.form.hasTime));
   }

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -49,6 +49,28 @@ class ActivityFormView extends StatelessWidget {
                   const SizedBox(height: 8),
                   const PictogramSelector(),
                   const SizedBox(height: 24),
+                  // Title field
+                  _TitleField(
+                    title: state.form.title,
+                    onChanged: cubit.setTitle,
+                  ),
+                  const SizedBox(height: 16),
+                  // Date picker
+                  _DatePicker(
+                    date: state.form.date,
+                    onTap: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: state.form.date,
+                        firstDate: DateTime(2020),
+                        lastDate: DateTime(2100),
+                      );
+                      if (picked != null && context.mounted) {
+                        cubit.setDate(picked);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 16),
                   // Time toggle
                   SwitchListTile(
                     title: const Text('Angiv tidspunkt'),
@@ -132,6 +154,92 @@ class ActivityFormView extends StatelessWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+/// Text field for the activity title.
+///
+/// Uses a [TextEditingController] to support bidirectional sync:
+/// user edits update the cubit, and external changes (e.g., pictogram
+/// selection auto-setting the title) update the text field.
+class _TitleField extends StatefulWidget {
+  const _TitleField({
+    required this.title,
+    required this.onChanged,
+  });
+
+  final String title;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_TitleField> createState() => _TitleFieldState();
+}
+
+class _TitleFieldState extends State<_TitleField> {
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.title;
+  }
+
+  @override
+  void didUpdateWidget(_TitleField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.title != oldWidget.title && widget.title != _controller.text) {
+      _controller.text = widget.title;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _controller,
+      onChanged: widget.onChanged,
+      decoration: const InputDecoration(
+        labelText: 'Titel',
+        hintText: 'Giv aktiviteten et navn',
+        prefixIcon: Icon(Icons.edit_outlined),
+      ),
+      maxLength: 200,
+      textCapitalization: TextCapitalization.sentences,
+    );
+  }
+}
+
+class _DatePicker extends StatelessWidget {
+  const _DatePicker({
+    required this.date,
+    required this.onTap,
+  });
+
+  final DateTime date;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dayName = GirafDateUtils.dayName(date.weekday);
+    final formatted = GirafDateUtils.formatDateDDMM(date);
+    return InkWell(
+      onTap: onTap,
+      child: InputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'Dato',
+          prefixIcon: Icon(Icons.calendar_today),
+        ),
+        child: Text(
+          '$dayName $formatted',
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
       ),
     );
   }

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -85,6 +85,36 @@ void main() {
     });
   });
 
+  group('setTitle', () {
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'emits updated ActivityFormReady with new title',
+      build: buildCubit,
+      act: (cubit) => cubit.setTitle('Morgenmad'),
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.title,
+          'title',
+          'Morgenmad',
+        ),
+      ],
+    );
+  });
+
+  group('setDate', () {
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'emits updated ActivityFormReady with new date',
+      build: buildCubit,
+      act: (cubit) => cubit.setDate(DateTime(2026, 4, 1)),
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.date,
+          'date',
+          DateTime(2026, 4, 1),
+        ),
+      ],
+    );
+  });
+
   group('setStartTime', () {
     blocTest<ActivityFormCubit, ActivityFormState>(
       'emits updated ActivityFormReady with new start time',

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -48,6 +48,41 @@ void main() {
       expect(find.text('Tilføj'), findsOneWidget);
     });
 
+    testWidgets('shows title field with current title value', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: testDate, title: 'Morgenmad'),
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('Titel'), findsOneWidget);
+      expect(find.text('Morgenmad'), findsOneWidget);
+    });
+
+    testWidgets('typing in title field calls setTitle', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: testDate),
+      ));
+      when(() => mockCubit.setTitle(any())).thenReturn(null);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.enterText(find.byType(TextFormField), 'Frokost');
+
+      verify(() => mockCubit.setTitle('Frokost')).called(1);
+    });
+
+    testWidgets('shows date picker field with formatted date', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: DateTime(2026, 3, 22)),
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('Dato'), findsOneWidget);
+      // 22/03 formatted, Sunday
+      expect(find.text('Søndag 22/03'), findsOneWidget);
+    });
+
     testWidgets('shows time pickers when hasTime is enabled', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: ActivityFormData(date: testDate, hasTime: true),


### PR DESCRIPTION
## Summary

- Adds a **title text field** to the activity create/edit form — the backend already supports `title` (max 200 chars) but the UI never exposed it. Every activity showed "Unavngivet aktivitet".
- Adds a **date picker** to the form — previously there was no way to change an activity's date from the UI, making it impossible to move activities between days.
- Adds `setTitle()` and `setDate()` methods to `ActivityFormCubit`.
- Title auto-fills from pictogram name on selection (existing behavior) but can now be manually overridden.

## Files Changed

| File | Change |
|------|--------|
| `activity_form_cubit.dart` | Added `setTitle()` and `setDate()` setters |
| `activity_form_view.dart` | Added `_TitleField` widget (StatefulWidget for controller sync) and `_DatePicker` widget |
| `activity_form_cubit_test.dart` | +2 test groups for new setters |
| `activity_form_view_test.dart` | +3 widget tests for title field and date picker |

## Test plan

- [x] All 201 tests pass (196 existing + 5 new)
- [x] `dart analyze` reports zero issues
- [ ] Manual: create activity → verify title field appears and saves
- [ ] Manual: edit activity → verify title pre-fills from existing value
- [ ] Manual: edit activity → change date → verify activity moves to new day
- [ ] Manual: select pictogram → verify title auto-fills with pictogram name
- [ ] Manual: select pictogram → manually override title → verify override persists

Closes #51, closes #60