### PR TITLE
feat: copy day's activities to another date

### DIFF
--- a/frontend/lib/core/errors/activity_failure.dart
+++ b/frontend/lib/core/errors/activity_failure.dart
@@ -41,3 +41,9 @@ final class ReorderActivitiesFailure extends ActivityFailure {
   const ReorderActivitiesFailure()
       : super('Kunne ikke ændre rækkefølge');
 }
+
+/// Failed to copy activities.
+final class CopyActivitiesFailure extends ActivityFailure {
+  const CopyActivitiesFailure()
+      : super('Kunne ikke kopiere aktiviteter');
+}

--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -121,4 +121,27 @@ class ActivityRepositoryImpl implements ActivityRepository {
       return Left(const ReorderActivitiesFailure());
     }
   }
+
+  @override
+  Future<Either<ActivityFailure, Unit>> copyActivities({
+    required int id,
+    required bool isCitizen,
+    required DateTime sourceDate,
+    required DateTime targetDate,
+    required List<int> activityIds,
+  }) async {
+    try {
+      await _apiService.copyActivities(
+        id: id,
+        isCitizen: isCitizen,
+        sourceDate: GirafDateUtils.formatQueryDate(sourceDate),
+        targetDate: GirafDateUtils.formatQueryDate(targetDate),
+        activityIds: activityIds,
+      );
+      return const Right(unit);
+    } catch (e, stackTrace) {
+      logServerError(_log, 'Failed to copy activities', e, stackTrace);
+      return Left(const CopyActivitiesFailure());
+    }
+  }
 }

--- a/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
@@ -40,4 +40,13 @@ abstract interface class ActivityRepository {
     required bool isCitizen,
     required List<Activity> activities,
   });
+
+  /// Copy activities to a different date.
+  Future<Either<ActivityFailure, Unit>> copyActivities({
+    required int id,
+    required bool isCitizen,
+    required DateTime sourceDate,
+    required DateTime targetDate,
+    required List<int> activityIds,
+  });
 }

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -31,6 +31,21 @@ class WeekplanView extends StatelessWidget {
         title: Text(
           subjectName != null ? 'Ugeplan — $subjectName' : 'Ugeplan',
         ),
+        actions: [
+          BlocBuilder<WeekplanCubit, WeekplanState>(
+            builder: (context, state) {
+              final hasActivities =
+                  state is WeekplanLoaded && state.activities.isNotEmpty;
+              return IconButton(
+                icon: const Icon(Icons.copy),
+                tooltip: 'Kopiér dag',
+                onPressed: hasActivities
+                    ? () => _showCopyDayPicker(context)
+                    : null,
+              );
+            },
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
@@ -73,6 +88,34 @@ class WeekplanView extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+}
+
+Future<void> _showCopyDayPicker(BuildContext context) async {
+  final cubit = context.read<WeekplanCubit>();
+  final sourceDate = cubit.state.selectedDate;
+
+  final targetDate = await showDatePicker(
+    context: context,
+    initialDate: sourceDate.add(const Duration(days: 1)),
+    firstDate: DateTime(2020),
+    lastDate: DateTime(2100),
+    helpText: 'Kopiér aktiviteter til',
+  );
+  if (targetDate == null || !context.mounted) return;
+
+  final error = await cubit.copyDayToDate(targetDate);
+  if (!context.mounted) return;
+
+  if (error != null) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(error)),
+    );
+  } else {
+    final formatted = GirafDateUtils.formatDateDDMM(targetDate);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Aktiviteter kopieret til $formatted')),
     );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -105,6 +105,11 @@ Future<void> _showCopyDayPicker(BuildContext context) async {
   );
   if (targetDate == null || !context.mounted) return;
 
+  final isSameDay = targetDate.year == sourceDate.year &&
+      targetDate.month == sourceDate.month &&
+      targetDate.day == sourceDate.day;
+  if (isSameDay) return;
+
   final error = await cubit.copyDayToDate(targetDate);
   if (!context.mounted) return;
 

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -209,6 +209,31 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     }
   }
 
+  /// Copy all current day's activities to a target date.
+  ///
+  /// Returns an error message on failure, or null on success.
+  Future<String?> copyDayToDate(DateTime targetDate) async {
+    final current = state;
+    if (current is! WeekplanLoaded) return null;
+    if (current.activities.isEmpty) return null;
+
+    final activityIds =
+        current.activities.map((a) => a.activityId).toList();
+
+    final result = await _activityRepository.copyActivities(
+      id: subjectId,
+      isCitizen: isCitizen,
+      sourceDate: current.selectedDate,
+      targetDate: targetDate,
+      activityIds: activityIds,
+    );
+
+    return switch (result) {
+      Left(:final value) => value.message,
+      Right() => null,
+    };
+  }
+
   /// Fetch image and sound URLs for pictograms in the given activities.
   Future<void> _fetchPictogramMedia(List<Activity> activities) async {
     final current = state;

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -104,6 +104,27 @@ class ActivityApiService implements TokenConsumer {
     await _dio.put(path, data: items);
   }
 
+  // Copy activities to a different date
+  Future<void> copyActivities({
+    required int id,
+    required bool isCitizen,
+    required String sourceDate,
+    required String targetDate,
+    required List<int> activityIds,
+  }) async {
+    final path = isCitizen
+        ? '/weekplan/activity/copy-citizen/$id'
+        : '/weekplan/activity/copy-grade/$id';
+    await _dio.post(
+      path,
+      queryParameters: {
+        'sourceDate': sourceDate,
+        'targetDate': targetDate,
+        'toCopyIds': activityIds,
+      },
+    );
+  }
+
   // Toggle activity completion status
   Future<void> toggleActivityStatus(int activityId, {required bool isComplete}) async {
     await _dio.put(

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -120,8 +120,8 @@ class ActivityApiService implements TokenConsumer {
       queryParameters: {
         'sourceDate': sourceDate,
         'targetDate': targetDate,
-        'toCopyIds': activityIds,
       },
+      data: activityIds,
     );
   }
 

--- a/frontend/test/features/weekplan/weekplan_cubit_test.dart
+++ b/frontend/test/features/weekplan/weekplan_cubit_test.dart
@@ -17,6 +17,10 @@ class MockActivityRepository extends Mock implements ActivityRepository {}
 class MockPictogramRepository extends Mock implements PictogramRepository {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+  });
+
   late MockActivityRepository mockActivityRepo;
   late MockPictogramRepository mockPictogramRepo;
 
@@ -391,5 +395,80 @@ void main() {
       act: (cubit) => cubit.toggleActivityStatus(5),
       expect: () => <WeekplanState>[],
     );
+  });
+
+  group('copyDayToDate', () {
+    final loadedState = WeekplanLoaded(
+      selectedDate: testDate,
+      weekDates: testWeekDates,
+      activities: [testActivity, testActivityWithPictogram],
+    );
+
+    final targetDate = DateTime(2026, 3, 25);
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'returns null on success',
+      setUp: () {
+        when(() => mockActivityRepo.copyActivities(
+              id: any(named: 'id'),
+              isCitizen: any(named: 'isCitizen'),
+              sourceDate: any(named: 'sourceDate'),
+              targetDate: any(named: 'targetDate'),
+              activityIds: any(named: 'activityIds'),
+            )).thenAnswer((_) async => const Right(unit));
+      },
+      build: buildCubit,
+      seed: () => loadedState,
+      act: (cubit) => cubit.copyDayToDate(targetDate),
+      verify: (_) {
+        verify(() => mockActivityRepo.copyActivities(
+              id: 1,
+              isCitizen: true,
+              sourceDate: testDate,
+              targetDate: targetDate,
+              activityIds: [1, 2],
+            )).called(1);
+      },
+      expect: () => <WeekplanState>[],
+    );
+
+    test('returns error message on failure', () async {
+      when(() => mockActivityRepo.copyActivities(
+            id: any(named: 'id'),
+            isCitizen: any(named: 'isCitizen'),
+            sourceDate: any(named: 'sourceDate'),
+            targetDate: any(named: 'targetDate'),
+            activityIds: any(named: 'activityIds'),
+          )).thenAnswer((_) async => const Left(CopyActivitiesFailure()));
+
+      final cubit = buildCubit();
+      cubit.emit(loadedState);
+
+      final error = await cubit.copyDayToDate(targetDate);
+      expect(error, 'Kunne ikke kopiere aktiviteter');
+      cubit.close();
+    });
+
+    test('returns null when no activities', () async {
+      final emptyState = WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: const [],
+      );
+
+      final cubit = buildCubit();
+      cubit.emit(emptyState);
+
+      final error = await cubit.copyDayToDate(targetDate);
+      expect(error, isNull);
+      verifyNever(() => mockActivityRepo.copyActivities(
+            id: any(named: 'id'),
+            isCitizen: any(named: 'isCitizen'),
+            sourceDate: any(named: 'sourceDate'),
+            targetDate: any(named: 'targetDate'),
+            activityIds: any(named: 'activityIds'),
+          ));
+      cubit.close();
+    });
   });
 }


### PR DESCRIPTION
## Summary

Wires up the backend's existing copy endpoints (`POST /weekplan/activity/copy-citizen|grade`) in the Flutter frontend. Users can now copy all activities from the current day to any other date.

- **App bar**: Copy icon button (disabled when no activities on the current day)
- **Flow**: Tap copy icon → date picker opens → select target date → activities copied → success snackbar
- **Full stack**: API service → repository (with `Either` error handling) → cubit → UI

## Files Changed

| Layer | File | Change |
|-------|------|--------|
| API | `activity_api_service.dart` | `copyActivities()` — POST with sourceDate, targetDate, toCopyIds |
| Domain | `activity_repository.dart` (interface) | `copyActivities()` contract |
| Data | `activity_repository.dart` (impl) | `copyActivities()` with error handling |
| Errors | `activity_failure.dart` | `CopyActivitiesFailure` |
| Cubit | `weekplan_cubit.dart` | `copyDayToDate()` — collects IDs, calls repo |
| View | `weekplan_view.dart` | Copy button in app bar, date picker, success/error snackbar |
| Tests | `weekplan_cubit_test.dart` | 3 tests: success, failure, empty activities |

## Test plan

- [x] All 212 tests pass (209 baseline + 3 new)
- [x] `dart analyze` reports zero issues
- [ ] Manual: view day with activities → tap copy icon → select date → verify snackbar
- [ ] Manual: navigate to target date → verify copied activities appear (isCompleted = false)
- [ ] Manual: view day with no activities → verify copy button is disabled
- [ ] Manual: copy fails (e.g., network error) → verify error snackbar

Closes #52