### PR TITLE
feat: week overview with day/week view toggle

### DIFF
--- a/frontend/lib/features/weekplan/domain/weekplan_state.dart
+++ b/frontend/lib/features/weekplan/domain/weekplan_state.dart
@@ -38,16 +38,21 @@ final class WeekplanLoaded extends WeekplanState {
   /// Cached media URLs keyed by pictogram ID.
   final Map<int, PictogramMedia> pictogramMedia;
 
+  /// Activities for all days in the week, keyed by date string (yyyy-MM-dd).
+  /// Empty until [WeekplanCubit.loadWeekActivities] is called.
+  final Map<String, List<Activity>> weekActivities;
+
   const WeekplanLoaded({
     required super.selectedDate,
     required super.weekDates,
     required this.activities,
     this.pictogramMedia = const {},
+    this.weekActivities = const {},
   });
 
   @override
   List<Object?> get props =>
-      [selectedDate, weekDates, activities, pictogramMedia];
+      [selectedDate, weekDates, activities, pictogramMedia, weekActivities];
 }
 
 /// An error occurred while fetching activities.

--- a/frontend/lib/features/weekplan/domain/weekplan_state.dart
+++ b/frontend/lib/features/weekplan/domain/weekplan_state.dart
@@ -50,6 +50,22 @@ final class WeekplanLoaded extends WeekplanState {
     this.weekActivities = const {},
   });
 
+  WeekplanLoaded copyWith({
+    DateTime? selectedDate,
+    List<DateTime>? weekDates,
+    List<Activity>? activities,
+    Map<int, PictogramMedia>? pictogramMedia,
+    Map<String, List<Activity>>? weekActivities,
+  }) {
+    return WeekplanLoaded(
+      selectedDate: selectedDate ?? this.selectedDate,
+      weekDates: weekDates ?? this.weekDates,
+      activities: activities ?? this.activities,
+      pictogramMedia: pictogramMedia ?? this.pictogramMedia,
+      weekActivities: weekActivities ?? this.weekActivities,
+    );
+  }
+
   @override
   List<Object?> get props =>
       [selectedDate, weekDates, activities, pictogramMedia, weekActivities];

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -6,11 +6,15 @@ import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/weekplan_cubit.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/activity_list_item.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/week_overview.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/week_selector.dart';
 import 'package:weekplanner/shared/models/activity.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
-class WeekplanView extends StatelessWidget {
+/// Weekplan screen with toggle between day view and week overview.
+///
+/// Uses [StatefulWidget] for the ephemeral view-mode toggle state.
+class WeekplanView extends StatefulWidget {
   final int citizenId;
   final bool isCitizen;
   final int? orgId;
@@ -25,64 +29,106 @@ class WeekplanView extends StatelessWidget {
   });
 
   @override
+  State<WeekplanView> createState() => _WeekplanViewState();
+}
+
+class _WeekplanViewState extends State<WeekplanView> {
+  bool _isWeekView = false;
+
+  void _toggleViewMode() {
+    setState(() {
+      _isWeekView = !_isWeekView;
+    });
+    if (_isWeekView) {
+      context.read<WeekplanCubit>().loadWeekActivities();
+    }
+  }
+
+  void _switchToDayView(DateTime date) {
+    setState(() {
+      _isWeekView = false;
+    });
+    context.read<WeekplanCubit>().selectDate(date);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          subjectName != null ? 'Ugeplan — $subjectName' : 'Ugeplan',
+          widget.subjectName != null
+              ? 'Ugeplan — ${widget.subjectName}'
+              : 'Ugeplan',
         ),
         actions: [
-          BlocBuilder<WeekplanCubit, WeekplanState>(
-            builder: (context, state) {
-              final hasActivities =
-                  state is WeekplanLoaded && state.activities.isNotEmpty;
-              return IconButton(
-                icon: const Icon(Icons.copy),
-                tooltip: 'Kopiér dag',
-                onPressed: hasActivities
-                    ? () => _showCopyDayPicker(context)
-                    : null,
-              );
-            },
+          IconButton(
+            icon: Icon(_isWeekView ? Icons.view_day : Icons.view_week),
+            tooltip: _isWeekView ? 'Dagvisning' : 'Ugeoversigt',
+            onPressed: _toggleViewMode,
           ),
+          if (!_isWeekView)
+            BlocBuilder<WeekplanCubit, WeekplanState>(
+              builder: (context, state) {
+                final hasActivities =
+                    state is WeekplanLoaded && state.activities.isNotEmpty;
+                return IconButton(
+                  icon: const Icon(Icons.copy),
+                  tooltip: 'Kopiér dag',
+                  onPressed: hasActivities
+                      ? () => _showCopyDayPicker(context)
+                      : null,
+                );
+              },
+            ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          final selectedDate = context.read<WeekplanCubit>().state.selectedDate;
-          final dateStr = selectedDate.toIso8601String().split('T').first;
-          final saved = await context.push<bool>(
-            '/weekplan/$citizenId/add?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
-          );
-          if (saved == true && context.mounted) {
-            context.read<WeekplanCubit>().loadActivities();
-          }
-        },
-        backgroundColor: context.colorScheme.primary,
-        child: Icon(Icons.add, color: context.colorScheme.onPrimary),
-      ),
+      floatingActionButton: _isWeekView
+          ? null
+          : FloatingActionButton(
+              onPressed: () async {
+                final selectedDate =
+                    context.read<WeekplanCubit>().state.selectedDate;
+                final dateStr =
+                    selectedDate.toIso8601String().split('T').first;
+                final saved = await context.push<bool>(
+                  '/weekplan/${widget.citizenId}/add?type=${widget.isCitizen ? 'citizen' : 'grade'}&orgId=${widget.orgId}&date=$dateStr',
+                );
+                if (saved == true && context.mounted) {
+                  context.read<WeekplanCubit>().loadActivities();
+                }
+              },
+              backgroundColor: context.colorScheme.primary,
+              child: Icon(Icons.add, color: context.colorScheme.onPrimary),
+            ),
       body: BlocBuilder<WeekplanCubit, WeekplanState>(
         builder: (context, state) {
           final cubit = context.read<WeekplanCubit>();
           return Column(
             children: [
-              WeekSelector(
-                weekNumber: cubit.weekNumber,
-                weekDates: state.weekDates,
-                selectedDate: state.selectedDate,
-                onPreviousWeek: cubit.goToPreviousWeek,
-                onNextWeek: cubit.goToNextWeek,
-                onGoToToday: cubit.goToToday,
-                onSelectDate: cubit.selectDate,
-              ),
-              const Divider(height: 1),
-              Expanded(
-                child: _ActivityListArea(
-                  state: state,
-                  citizenId: citizenId,
-                  isCitizen: isCitizen,
-                  orgId: orgId,
+              if (!_isWeekView) ...[
+                WeekSelector(
+                  weekNumber: cubit.weekNumber,
+                  weekDates: state.weekDates,
+                  selectedDate: state.selectedDate,
+                  onPreviousWeek: cubit.goToPreviousWeek,
+                  onNextWeek: cubit.goToNextWeek,
+                  onGoToToday: cubit.goToToday,
+                  onSelectDate: cubit.selectDate,
                 ),
+                const Divider(height: 1),
+              ],
+              Expanded(
+                child: _isWeekView
+                    ? _WeekOverviewArea(
+                        state: state,
+                        onSelectDay: _switchToDayView,
+                      )
+                    : _ActivityListArea(
+                        state: state,
+                        citizenId: widget.citizenId,
+                        isCitizen: widget.isCitizen,
+                        orgId: widget.orgId,
+                      ),
               ),
             ],
           );
@@ -122,6 +168,35 @@ Future<void> _showCopyDayPicker(BuildContext context) async {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Aktiviteter kopieret til $formatted')),
     );
+  }
+}
+
+class _WeekOverviewArea extends StatelessWidget {
+  final WeekplanState state;
+  final ValueChanged<DateTime> onSelectDay;
+
+  const _WeekOverviewArea({
+    required this.state,
+    required this.onSelectDay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      WeekplanLoading() => const Center(child: CircularProgressIndicator()),
+      WeekplanError(:final message) => _ErrorWithRetry(message: message),
+      WeekplanLoaded(
+        :final weekDates,
+        :final weekActivities,
+        :final pictogramMedia,
+      ) =>
+        WeekOverview(
+          weekDates: weekDates,
+          weekActivities: weekActivities,
+          pictogramMedia: pictogramMedia,
+          onSelectDay: onSelectDay,
+        ),
+    };
   }
 }
 

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -93,23 +93,13 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     final updated =
         backup.where((a) => a.activityId != activityId).toList();
 
-    emit(WeekplanLoaded(
-      selectedDate: current.selectedDate,
-      weekDates: current.weekDates,
-      activities: updated,
-      pictogramMedia: current.pictogramMedia,
-    ));
+    emit(current.copyWith(activities: updated));
 
     final result = await _activityRepository.deleteActivity(activityId);
     switch (result) {
       case Left(:final value):
         _log.warning('Delete rollback: ${value.message}');
-        emit(WeekplanLoaded(
-          selectedDate: current.selectedDate,
-          weekDates: current.weekDates,
-          activities: backup,
-          pictogramMedia: current.pictogramMedia,
-        ));
+        emit(current.copyWith(activities: backup));
       case Right():
         break;
     }
@@ -132,12 +122,7 @@ class WeekplanCubit extends Cubit<WeekplanState> {
       return a;
     }).toList();
 
-    emit(WeekplanLoaded(
-      selectedDate: current.selectedDate,
-      weekDates: current.weekDates,
-      activities: updated,
-      pictogramMedia: current.pictogramMedia,
-    ));
+    emit(current.copyWith(activities: updated));
 
     final result = await _activityRepository.toggleActivityStatus(
       activityId,
@@ -152,12 +137,7 @@ class WeekplanCubit extends Cubit<WeekplanState> {
           }
           return a;
         }).toList();
-        emit(WeekplanLoaded(
-          selectedDate: current.selectedDate,
-          weekDates: current.weekDates,
-          activities: rolledBack,
-          pictogramMedia: current.pictogramMedia,
-        ));
+        emit(current.copyWith(activities: rolledBack));
       case Right():
         break;
     }
@@ -183,12 +163,7 @@ class WeekplanCubit extends Cubit<WeekplanState> {
         reordered[i].copyWith(sortOrder: i),
     ];
 
-    emit(WeekplanLoaded(
-      selectedDate: current.selectedDate,
-      weekDates: current.weekDates,
-      activities: withSortOrder,
-      pictogramMedia: current.pictogramMedia,
-    ));
+    emit(current.copyWith(activities: withSortOrder));
 
     final result = await _activityRepository.reorderActivities(
       id: subjectId,
@@ -198,12 +173,7 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     switch (result) {
       case Left(:final value):
         _log.warning('Reorder rollback: ${value.message}');
-        emit(WeekplanLoaded(
-          selectedDate: current.selectedDate,
-          weekDates: current.weekDates,
-          activities: backup,
-          pictogramMedia: current.pictogramMedia,
-        ));
+        emit(current.copyWith(activities: backup));
       case Right():
         break;
     }
@@ -242,13 +212,7 @@ class WeekplanCubit extends Cubit<WeekplanState> {
       }
     }
 
-    emit(WeekplanLoaded(
-      selectedDate: afterState.selectedDate,
-      weekDates: afterState.weekDates,
-      activities: afterState.activities,
-      pictogramMedia: afterState.pictogramMedia,
-      weekActivities: weekMap,
-    ));
+    emit(afterState.copyWith(weekActivities: weekMap));
   }
 
   /// Copy all current day's activities to a target date.
@@ -313,11 +277,6 @@ class WeekplanCubit extends Cubit<WeekplanState> {
       }
     }
 
-    emit(WeekplanLoaded(
-      selectedDate: afterState.selectedDate,
-      weekDates: afterState.weekDates,
-      activities: afterState.activities,
-      pictogramMedia: updatedMedia,
-    ));
+    emit(afterState.copyWith(pictogramMedia: updatedMedia));
   }
 }

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -209,6 +209,48 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     }
   }
 
+  /// Load activities for all 7 days in the current week.
+  ///
+  /// Stores results in [WeekplanLoaded.weekActivities] keyed by date string.
+  Future<void> loadWeekActivities() async {
+    final current = state;
+    if (current is! WeekplanLoaded) return;
+
+    final results = await Future.wait(
+      current.weekDates.map((date) async {
+        final result = await _activityRepository.fetchActivities(
+          id: subjectId,
+          isCitizen: isCitizen,
+          date: date,
+        );
+        final dateKey = GirafDateUtils.formatQueryDate(date);
+        return (dateKey, result);
+      }),
+    );
+
+    // Re-check state hasn't changed during async gap
+    final afterState = state;
+    if (afterState is! WeekplanLoaded) return;
+
+    final weekMap = <String, List<Activity>>{};
+    for (final (dateKey, result) in results) {
+      switch (result) {
+        case Left():
+          weekMap[dateKey] = const [];
+        case Right(:final value):
+          weekMap[dateKey] = value;
+      }
+    }
+
+    emit(WeekplanLoaded(
+      selectedDate: afterState.selectedDate,
+      weekDates: afterState.weekDates,
+      activities: afterState.activities,
+      pictogramMedia: afterState.pictogramMedia,
+      weekActivities: weekMap,
+    ));
+  }
+
   /// Copy all current day's activities to a target date.
   ///
   /// Returns an error message on failure, or null on success.

--- a/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+
+import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
+import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/utils/date_utils.dart';
+
+/// Displays a condensed overview of all 7 days in the week.
+///
+/// Each day shows its name, date, and a list of activity summaries
+/// (pictogram placeholder + title). Tapping a day header switches
+/// to the day view for that day.
+class WeekOverview extends StatelessWidget {
+  final List<DateTime> weekDates;
+  final Map<String, List<Activity>> weekActivities;
+  final Map<int, PictogramMedia> pictogramMedia;
+  final ValueChanged<DateTime> onSelectDay;
+
+  const WeekOverview({
+    super.key,
+    required this.weekDates,
+    required this.weekActivities,
+    required this.pictogramMedia,
+    required this.onSelectDay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (weekActivities.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: weekDates.length,
+      itemBuilder: (context, index) {
+        final date = weekDates[index];
+        final dateKey = GirafDateUtils.formatQueryDate(date);
+        final activities = weekActivities[dateKey] ?? const [];
+        return _DayColumn(
+          date: date,
+          activities: activities,
+          pictogramMedia: pictogramMedia,
+          onTap: () => onSelectDay(date),
+        );
+      },
+    );
+  }
+}
+
+class _DayColumn extends StatelessWidget {
+  final DateTime date;
+  final List<Activity> activities;
+  final Map<int, PictogramMedia> pictogramMedia;
+  final VoidCallback onTap;
+
+  const _DayColumn({
+    required this.date,
+    required this.activities,
+    required this.pictogramMedia,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final isToday = date.day == now.day &&
+        date.month == now.month &&
+        date.year == now.year;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _DayHeader(date: date, isToday: isToday),
+              if (activities.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Ingen aktiviteter',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: context.colorScheme.outline,
+                          fontStyle: FontStyle.italic,
+                        ),
+                  ),
+                )
+              else
+                ...activities.map(
+                  (a) => _ActivityRow(
+                    activity: a,
+                    imageUrl: a.pictogramId != null
+                        ? pictogramMedia[a.pictogramId!]?.imageUrl
+                        : null,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DayHeader extends StatelessWidget {
+  final DateTime date;
+  final bool isToday;
+
+  const _DayHeader({required this.date, required this.isToday});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          '${GirafDateUtils.dayName(date.weekday)} ${GirafDateUtils.formatDateDDMM(date)}',
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: isToday ? context.colorScheme.primary : null,
+              ),
+        ),
+        if (isToday) ...[
+          const SizedBox(width: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: context.colorScheme.primary,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              'I dag',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: context.colorScheme.onPrimary,
+                  ),
+            ),
+          ),
+        ],
+        const Spacer(),
+        Icon(
+          Icons.chevron_right,
+          color: context.colorScheme.outline,
+          size: 20,
+        ),
+      ],
+    );
+  }
+}
+
+class _ActivityRow extends StatelessWidget {
+  final Activity activity;
+  final String? imageUrl;
+
+  const _ActivityRow({
+    required this.activity,
+    this.imageUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        children: [
+          // Small pictogram thumbnail
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: activity.isCompleted
+                  ? context.girafColors.completedBackground
+                  : context.colorScheme.primaryContainer,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: imageUrl != null
+                ? Image.network(
+                    imageUrl!,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, _, _) => Icon(
+                      Icons.image,
+                      size: 16,
+                      color: context.colorScheme.onPrimaryContainer,
+                    ),
+                  )
+                : Icon(
+                    Icons.event,
+                    size: 16,
+                    color: context.colorScheme.onPrimaryContainer,
+                  ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              activity.title ?? 'Unavngivet aktivitet',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    decoration: activity.isCompleted
+                        ? TextDecoration.lineThrough
+                        : null,
+                    color: activity.isCompleted
+                        ? context.colorScheme.outline
+                        : null,
+                  ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (activity.isCompleted)
+            Icon(
+              Icons.check_circle,
+              size: 16,
+              color: context.girafColors.completedIndicator,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/test/features/weekplan/weekplan_cubit_test.dart
+++ b/frontend/test/features/weekplan/weekplan_cubit_test.dart
@@ -471,4 +471,47 @@ void main() {
       cubit.close();
     });
   });
+
+  group('loadWeekActivities', () {
+    final loadedState = WeekplanLoaded(
+      selectedDate: testDate,
+      weekDates: testWeekDates,
+      activities: [testActivity],
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'fetches activities for all 7 days and emits weekActivities map',
+      setUp: () {
+        when(() => mockActivityRepo.fetchActivities(
+              id: any(named: 'id'),
+              isCitizen: any(named: 'isCitizen'),
+              date: any(named: 'date'),
+            )).thenAnswer((_) async => const Right(<Activity>[]));
+      },
+      build: buildCubit,
+      seed: () => loadedState,
+      act: (cubit) => cubit.loadWeekActivities(),
+      verify: (_) {
+        verify(() => mockActivityRepo.fetchActivities(
+              id: any(named: 'id'),
+              isCitizen: any(named: 'isCitizen'),
+              date: any(named: 'date'),
+            )).called(7);
+      },
+      expect: () => [
+        isA<WeekplanLoaded>().having(
+          (s) => s.weekActivities.length,
+          'weekActivities length',
+          7,
+        ),
+      ],
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'does nothing when state is not WeekplanLoaded',
+      build: buildCubit,
+      act: (cubit) => cubit.loadWeekActivities(),
+      expect: () => <WeekplanState>[],
+    );
+  });
 }

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -238,5 +238,38 @@ void main() {
       // deleteActivity should NOT have been called
       verifyNever(() => mockCubit.deleteActivity(any()));
     });
+
+    testWidgets('shows week view toggle button', (tester) async {
+      when(() => mockCubit.state).thenReturn(WeekplanLoading(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.byIcon(Icons.view_week), findsOneWidget);
+      expect(find.byTooltip('Ugeoversigt'), findsOneWidget);
+    });
+
+    testWidgets('tapping toggle switches to week view and calls loadWeekActivities',
+        (tester) async {
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: const [],
+        weekActivities: const {},
+      ));
+      when(() => mockCubit.loadWeekActivities())
+          .thenAnswer((_) async {});
+
+      await tester.pumpWidget(buildSubject());
+
+      await tester.tap(find.byIcon(Icons.view_week));
+      await tester.pump();
+
+      verify(() => mockCubit.loadWeekActivities()).called(1);
+      // Icon should switch to day view
+      expect(find.byIcon(Icons.view_day), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Adds a week overview mode to the weekplan, allowing caregivers to see all 7 days of activities at a glance. Toggle between day view (existing) and week overview via an icon button in the app bar.

- **Toggle button**: `view_week` / `view_day` icon in app bar switches modes
- **Week overview**: Condensed vertical list of all 7 days, each showing activity thumbnails (32x32 pictogram + title), today badge, completion strikethrough
- **Tap to navigate**: Tapping any day card switches to day view for that day
- **Data loading**: 7 parallel API calls via `loadWeekActivities()` (no new backend endpoint needed)
- **Smart UI**: FAB and copy button hidden in week view mode; week selector hidden in week view

## Files Changed

| File | Change |
|------|--------|
| `weekplan_state.dart` | Added `weekActivities` map to `WeekplanLoaded` |
| `weekplan_cubit.dart` | Added `loadWeekActivities()` — 7 parallel fetches |
| `weekplan_view.dart` | Converted to `StatefulWidget` for view toggle, added `_WeekOverviewArea` |
| `week_overview.dart` | **New** — `WeekOverview`, `_DayColumn`, `_DayHeader`, `_ActivityRow` widgets |
| `weekplan_cubit_test.dart` | +2 tests (fetches 7 days, no-op when not loaded) |
| `weekplan_view_test.dart` | +2 tests (toggle button exists, toggle calls loadWeekActivities) |

## Test plan

- [x] All 216 tests pass (212 baseline + 4 new)
- [x] `dart analyze` reports zero issues
- [ ] Manual: tap week view icon → verify all 7 days shown with activities
- [ ] Manual: tap a day card → verify switches to day view for that day
- [ ] Manual: verify today badge shows on correct day
- [ ] Manual: verify completed activities show strikethrough
- [ ] Manual: verify FAB is hidden in week view
- [ ] Manual: toggle back to day view → verify day view works normally

Closes #55