### PR TITLE
feat: undo snackbar for activity deletion

### DIFF
--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -382,7 +382,7 @@ class _ActivityList extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(
-          'Aktivitet "${activity.title ?? 'Unavngivet'}" slettet',
+          'Aktivitet "${activity.title ?? 'denne aktivitet'}" slettet',
         ),
         duration: const Duration(seconds: 5),
         action: SnackBarAction(
@@ -394,7 +394,7 @@ class _ActivityList extends StatelessWidget {
         ),
       ),
     ).closed.then((_) {
-      if (!undone) {
+      if (!undone && context.mounted) {
         cubit.confirmDelete(activity.activityId, removed);
       }
     });

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -372,8 +372,31 @@ class _ActivityList extends StatelessWidget {
         ],
       ),
     );
-    if (confirmed == true) {
-      cubit.deleteActivity(activity.activityId);
-    }
+    if (confirmed != true || !context.mounted) return;
+
+    final removed = cubit.hideActivity(activity.activityId);
+    if (removed == null || !context.mounted) return;
+
+    var undone = false;
+    ScaffoldMessenger.of(context).clearSnackBars();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Aktivitet "${activity.title ?? 'Unavngivet'}" slettet',
+        ),
+        duration: const Duration(seconds: 5),
+        action: SnackBarAction(
+          label: 'Fortryd',
+          onPressed: () {
+            undone = true;
+            cubit.restoreActivity(removed);
+          },
+        ),
+      ),
+    ).closed.then((_) {
+      if (!undone) {
+        cubit.confirmDelete(activity.activityId, removed);
+      }
+    });
   }
 }

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -84,22 +84,45 @@ class WeekplanCubit extends Cubit<WeekplanState> {
   /// Navigate to today.
   Future<void> goToToday() => selectDate(DateTime.now());
 
-  /// Optimistically delete an activity.
-  Future<void> deleteActivity(int activityId) async {
+  /// Remove an activity from the UI without calling the server.
+  ///
+  /// Returns the removed [Activity] so the caller can undo or confirm.
+  /// Returns null if the activity was not found or state is not loaded.
+  Activity? hideActivity(int activityId) {
+    final current = state;
+    if (current is! WeekplanLoaded) return null;
+
+    final index =
+        current.activities.indexWhere((a) => a.activityId == activityId);
+    if (index == -1) return null;
+
+    final removed = current.activities[index];
+    final updated =
+        current.activities.where((a) => a.activityId != activityId).toList();
+    emit(current.copyWith(activities: updated));
+    return removed;
+  }
+
+  /// Restore a previously hidden activity to the list.
+  void restoreActivity(Activity activity) {
     final current = state;
     if (current is! WeekplanLoaded) return;
 
-    final backup = current.activities;
-    final updated =
-        backup.where((a) => a.activityId != activityId).toList();
+    final restored = [...current.activities, activity]
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    emit(current.copyWith(activities: restored));
+  }
 
-    emit(current.copyWith(activities: updated));
-
+  /// Permanently delete an activity on the server.
+  ///
+  /// Call after the undo window has passed. If the server call fails,
+  /// the activity is restored to the list.
+  Future<void> confirmDelete(int activityId, Activity backup) async {
     final result = await _activityRepository.deleteActivity(activityId);
     switch (result) {
       case Left(:final value):
-        _log.warning('Delete rollback: ${value.message}');
-        emit(current.copyWith(activities: backup));
+        _log.warning('Delete failed, restoring: ${value.message}');
+        restoreActivity(backup);
       case Right():
         break;
     }

--- a/frontend/test/features/weekplan/weekplan_cubit_test.dart
+++ b/frontend/test/features/weekplan/weekplan_cubit_test.dart
@@ -244,7 +244,7 @@ void main() {
     );
   });
 
-  group('deleteActivity', () {
+  group('hideActivity', () {
     final activityToDelete = Activity(
       activityId: 99,
       date: DateTime(2026, 3, 22),
@@ -259,51 +259,105 @@ void main() {
     );
 
     blocTest<WeekplanCubit, WeekplanState>(
-      'optimistically removes activity from list on success',
+      'removes activity from list and returns it',
+      build: buildCubit,
+      seed: () => loadedState,
+      act: (cubit) {
+        final removed = cubit.hideActivity(99);
+        expect(removed, activityToDelete);
+      },
+      expect: () => [
+        WeekplanLoaded(
+          selectedDate: testDate,
+          weekDates: testWeekDates,
+          activities: [testActivity],
+        ),
+      ],
+    );
+
+    test('returns null when state is not WeekplanLoaded', () {
+      final cubit = buildCubit();
+      expect(cubit.hideActivity(1), isNull);
+      cubit.close();
+    });
+
+    test('returns null when activity id not found', () {
+      final cubit = buildCubit();
+      cubit.emit(loadedState);
+      expect(cubit.hideActivity(999), isNull);
+      cubit.close();
+    });
+  });
+
+  group('restoreActivity', () {
+    final activityToRestore = Activity(
+      activityId: 99,
+      date: DateTime(2026, 3, 22),
+      sortOrder: 0,
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'adds activity back in sort order',
+      build: buildCubit,
+      seed: () => WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: [testActivity.copyWith(sortOrder: 1)],
+      ),
+      act: (cubit) => cubit.restoreActivity(activityToRestore),
+      expect: () => [
+        isA<WeekplanLoaded>().having(
+          (s) => s.activities.length,
+          'activities length',
+          2,
+        ),
+      ],
+    );
+  });
+
+  group('confirmDelete', () {
+    final deletedActivity = Activity(
+      activityId: 99,
+      date: DateTime(2026, 3, 22),
+    );
+
+    final loadedState = WeekplanLoaded(
+      selectedDate: testDate,
+      weekDates: testWeekDates,
+      activities: [testActivity],
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'calls server delete, no state change on success',
       setUp: () {
         when(() => mockActivityRepo.deleteActivity(99))
             .thenAnswer((_) async => const Right(unit));
       },
       build: buildCubit,
       seed: () => loadedState,
-      act: (cubit) => cubit.deleteActivity(99),
-      expect: () => [
-        WeekplanLoaded(
-          selectedDate: testDate,
-          weekDates: testWeekDates,
-          activities: [testActivity],
-        ),
-      ],
+      act: (cubit) => cubit.confirmDelete(99, deletedActivity),
+      expect: () => <WeekplanState>[],
       verify: (_) {
         verify(() => mockActivityRepo.deleteActivity(99)).called(1);
       },
     );
 
     blocTest<WeekplanCubit, WeekplanState>(
-      'rolls back to original list on failure',
+      'restores activity on server failure',
       setUp: () {
         when(() => mockActivityRepo.deleteActivity(99))
             .thenAnswer((_) async => const Left(DeleteActivityFailure()));
       },
       build: buildCubit,
       seed: () => loadedState,
-      act: (cubit) => cubit.deleteActivity(99),
+      act: (cubit) => cubit.confirmDelete(99, deletedActivity),
       expect: () => [
-        WeekplanLoaded(
-          selectedDate: testDate,
-          weekDates: testWeekDates,
-          activities: [testActivity],
+        isA<WeekplanLoaded>().having(
+          (s) => s.activities.length,
+          'activities length',
+          2,
         ),
-        loadedState,
       ],
-    );
-
-    blocTest<WeekplanCubit, WeekplanState>(
-      'does nothing when state is not WeekplanLoaded',
-      build: buildCubit,
-      // Initial state is WeekplanLoading
-      act: (cubit) => cubit.deleteActivity(1),
-      expect: () => <WeekplanState>[],
     );
   });
 

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -177,22 +177,19 @@ void main() {
       expect(find.text('Annuller'), findsOneWidget);
     });
 
-    testWidgets('delete confirmation confirm calls deleteActivity',
+    testWidgets('delete confirmation confirm hides activity and shows undo snackbar',
         (tester) async {
-      final activities = [
-        Activity(
-          activityId: 1,
-          date: DateTime(2026, 3, 22),
-          title: 'Morgenmad',
-        ),
-      ];
+      final activity = Activity(
+        activityId: 1,
+        date: DateTime(2026, 3, 22),
+        title: 'Morgenmad',
+      );
       when(() => mockCubit.state).thenReturn(WeekplanLoaded(
         selectedDate: testDate,
         weekDates: testWeekDates,
-        activities: activities,
+        activities: [activity],
       ));
-      when(() => mockCubit.deleteActivity(any()))
-          .thenAnswer((_) async {});
+      when(() => mockCubit.hideActivity(any())).thenReturn(activity);
 
       await tester.pumpWidget(buildSubject());
 
@@ -206,7 +203,40 @@ void main() {
       await tester.tap(find.text('Slet').last);
       await tester.pumpAndSettle();
 
-      verify(() => mockCubit.deleteActivity(1)).called(1);
+      verify(() => mockCubit.hideActivity(1)).called(1);
+      // Undo snackbar should be visible
+      expect(find.text('Fortryd'), findsOneWidget);
+    });
+
+    testWidgets('tapping undo in snackbar restores activity',
+        (tester) async {
+      final activity = Activity(
+        activityId: 1,
+        date: DateTime(2026, 3, 22),
+        title: 'Morgenmad',
+      );
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: [activity],
+      ));
+      when(() => mockCubit.hideActivity(any())).thenReturn(activity);
+
+      await tester.pumpWidget(buildSubject());
+
+      // Swipe → delete → confirm
+      await tester.drag(find.text('Morgenmad'), const Offset(-300, 0));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Slet').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Slet').last);
+      await tester.pumpAndSettle();
+
+      // Tap undo
+      await tester.tap(find.text('Fortryd'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCubit.restoreActivity(activity)).called(1);
     });
 
     testWidgets('delete confirmation cancel does not delete', (tester) async {
@@ -235,8 +265,8 @@ void main() {
       await tester.tap(find.text('Annuller'));
       await tester.pumpAndSettle();
 
-      // deleteActivity should NOT have been called
-      verifyNever(() => mockCubit.deleteActivity(any()));
+      // hideActivity should NOT have been called
+      verifyNever(() => mockCubit.hideActivity(any()));
     });
 
     testWidgets('shows week view toggle button', (tester) async {


### PR DESCRIPTION
## Summary

Adds a 5-second undo window after deleting an activity. Instead of immediately calling the server, the activity is hidden from the UI and a snackbar appears with a "Fortryd" (Undo) button. If tapped, the activity is restored. Otherwise, the server delete fires when the snackbar closes.

The delete flow is now: swipe → confirm dialog → hide from UI → show undo snackbar → (undo OR confirm to server).

## Changes

Split `deleteActivity()` into three cubit methods:
- **`hideActivity(id)`** — removes from UI list, returns the `Activity` for potential undo
- **`restoreActivity(activity)`** — re-inserts at correct sort position
- **`confirmDelete(id, backup)`** — calls server; restores on failure

View orchestrates: hide → snackbar → undo/confirm.

## Files Changed

| File | Change |
|------|--------|
| `weekplan_cubit.dart` | Replaced `deleteActivity` with `hideActivity`, `restoreActivity`, `confirmDelete` |
| `weekplan_view.dart` | Undo snackbar after delete confirmation, `clearSnackBars` before showing |
| `weekplan_cubit_test.dart` | Rewrote delete tests for 3 new methods (7 tests) |
| `weekplan_view_test.dart` | Updated delete tests: undo snackbar visible, undo restores, cancel doesn't hide |

## Test plan

- [x] All 220 tests pass (216 baseline, tests rewritten for new API)
- [x] `dart analyze` reports zero issues
- [ ] Manual: delete activity → verify snackbar appears with "Fortryd"
- [ ] Manual: tap "Fortryd" → verify activity reappears in list
- [ ] Manual: let snackbar expire → verify activity is permanently deleted
- [ ] Manual: delete fails on server → verify activity is restored

Closes #62