### PR TITLE
feat: multi-select with bulk delete, copy, and mark complete

### DIFF
--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -13,7 +13,7 @@ import 'package:weekplanner/shared/utils/date_utils.dart';
 
 /// Weekplan screen with toggle between day view and week overview.
 ///
-/// Uses [StatefulWidget] for the ephemeral view-mode toggle state.
+/// Uses [StatefulWidget] for ephemeral view-mode toggle and selection state.
 class WeekplanView extends StatefulWidget {
   final int citizenId;
   final bool isCitizen;
@@ -34,10 +34,13 @@ class WeekplanView extends StatefulWidget {
 
 class _WeekplanViewState extends State<WeekplanView> {
   bool _isWeekView = false;
+  bool _isSelecting = false;
+  final Set<int> _selectedIds = {};
 
   void _toggleViewMode() {
     setState(() {
       _isWeekView = !_isWeekView;
+      _exitSelectionMode();
     });
     if (_isWeekView) {
       context.read<WeekplanCubit>().loadWeekActivities();
@@ -47,42 +50,82 @@ class _WeekplanViewState extends State<WeekplanView> {
   void _switchToDayView(DateTime date) {
     setState(() {
       _isWeekView = false;
+      _exitSelectionMode();
     });
     context.read<WeekplanCubit>().selectDate(date);
+  }
+
+  void _enterSelectionMode(int activityId) {
+    setState(() {
+      _isSelecting = true;
+      _selectedIds.add(activityId);
+    });
+  }
+
+  void _toggleSelection(int activityId) {
+    setState(() {
+      if (_selectedIds.contains(activityId)) {
+        _selectedIds.remove(activityId);
+        if (_selectedIds.isEmpty) _isSelecting = false;
+      } else {
+        _selectedIds.add(activityId);
+      }
+    });
+  }
+
+  void _selectAll(List<Activity> activities) {
+    setState(() {
+      _selectedIds.addAll(activities.map((a) => a.activityId));
+    });
+  }
+
+  void _exitSelectionMode() {
+    _isSelecting = false;
+    _selectedIds.clear();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          widget.subjectName != null
-              ? 'Ugeplan — ${widget.subjectName}'
-              : 'Ugeplan',
-        ),
-        actions: [
-          IconButton(
-            icon: Icon(_isWeekView ? Icons.view_day : Icons.view_week),
-            tooltip: _isWeekView ? 'Dagvisning' : 'Ugeoversigt',
-            onPressed: _toggleViewMode,
-          ),
-          if (!_isWeekView)
-            BlocBuilder<WeekplanCubit, WeekplanState>(
-              builder: (context, state) {
-                final hasActivities =
-                    state is WeekplanLoaded && state.activities.isNotEmpty;
-                return IconButton(
-                  icon: const Icon(Icons.copy),
-                  tooltip: 'Kopiér dag',
-                  onPressed: hasActivities
-                      ? () => _showCopyDayPicker(context)
-                      : null,
-                );
+      appBar: _isSelecting
+          ? _SelectionAppBar(
+              selectedCount: _selectedIds.length,
+              onClose: () => setState(_exitSelectionMode),
+              onSelectAll: () {
+                final state = context.read<WeekplanCubit>().state;
+                if (state is WeekplanLoaded) _selectAll(state.activities);
               },
+            )
+          : AppBar(
+              title: Text(
+                widget.subjectName != null
+                    ? 'Ugeplan — ${widget.subjectName}'
+                    : 'Ugeplan',
+              ),
+              actions: [
+                IconButton(
+                  icon:
+                      Icon(_isWeekView ? Icons.view_day : Icons.view_week),
+                  tooltip: _isWeekView ? 'Dagvisning' : 'Ugeoversigt',
+                  onPressed: _toggleViewMode,
+                ),
+                if (!_isWeekView)
+                  BlocBuilder<WeekplanCubit, WeekplanState>(
+                    builder: (context, state) {
+                      final hasActivities = state is WeekplanLoaded &&
+                          state.activities.isNotEmpty;
+                      return IconButton(
+                        icon: const Icon(Icons.copy),
+                        tooltip: 'Kopiér dag',
+                        onPressed: hasActivities
+                            ? () => _showCopyDayPicker(context)
+                            : null,
+                      );
+                    },
+                  ),
+              ],
             ),
-        ],
-      ),
-      floatingActionButton: _isWeekView
+      floatingActionButton: _isWeekView || _isSelecting
           ? null
           : FloatingActionButton(
               onPressed: () async {
@@ -100,12 +143,20 @@ class _WeekplanViewState extends State<WeekplanView> {
               backgroundColor: context.colorScheme.primary,
               child: Icon(Icons.add, color: context.colorScheme.onPrimary),
             ),
+      bottomNavigationBar: _isSelecting
+          ? _SelectionActionBar(
+              selectedIds: _selectedIds,
+              citizenId: widget.citizenId,
+              isCitizen: widget.isCitizen,
+              onDone: () => setState(_exitSelectionMode),
+            )
+          : null,
       body: BlocBuilder<WeekplanCubit, WeekplanState>(
         builder: (context, state) {
           final cubit = context.read<WeekplanCubit>();
           return Column(
             children: [
-              if (!_isWeekView) ...[
+              if (!_isWeekView && !_isSelecting) ...[
                 WeekSelector(
                   weekNumber: cubit.weekNumber,
                   weekDates: state.weekDates,
@@ -128,6 +179,10 @@ class _WeekplanViewState extends State<WeekplanView> {
                         citizenId: widget.citizenId,
                         isCitizen: widget.isCitizen,
                         orgId: widget.orgId,
+                        isSelecting: _isSelecting,
+                        selectedIds: _selectedIds,
+                        onLongPress: _enterSelectionMode,
+                        onToggleSelection: _toggleSelection,
                       ),
               ),
             ],
@@ -171,6 +226,224 @@ Future<void> _showCopyDayPicker(BuildContext context) async {
   }
 }
 
+// ── Selection mode app bar ────────────────────────────────
+
+class _SelectionAppBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  final int selectedCount;
+  final VoidCallback onClose;
+  final VoidCallback onSelectAll;
+
+  const _SelectionAppBar({
+    required this.selectedCount,
+    required this.onClose,
+    required this.onSelectAll,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: onClose,
+      ),
+      title: Text('$selectedCount valgt'),
+      actions: [
+        TextButton(
+          onPressed: onSelectAll,
+          child: const Text('Vælg alle'),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Selection action bar ──────────────────────────────────
+
+class _SelectionActionBar extends StatelessWidget {
+  final Set<int> selectedIds;
+  final int citizenId;
+  final bool isCitizen;
+  final VoidCallback onDone;
+
+  const _SelectionActionBar({
+    required this.selectedIds,
+    required this.citizenId,
+    required this.isCitizen,
+    required this.onDone,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomAppBar(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _ActionButton(
+            icon: Icons.delete_outline,
+            label: 'Slet',
+            color: Theme.of(context).colorScheme.error,
+            onTap: () => _bulkDelete(context),
+          ),
+          _ActionButton(
+            icon: Icons.copy,
+            label: 'Kopiér',
+            onTap: () => _bulkCopy(context),
+          ),
+          _ActionButton(
+            icon: Icons.check_circle_outline,
+            label: 'Færdig',
+            onTap: () => _bulkComplete(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _bulkDelete(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Slet aktiviteter'),
+        content: Text(
+          'Er du sikker på du vil slette ${selectedIds.length} aktiviteter?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Annuller'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              'Slet',
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+
+    final cubit = context.read<WeekplanCubit>();
+    final removedActivities = <Activity>[];
+    for (final id in selectedIds) {
+      final removed = cubit.hideActivity(id);
+      if (removed != null) removedActivities.add(removed);
+    }
+    onDone();
+    if (!context.mounted) return;
+
+    var undone = false;
+    ScaffoldMessenger.of(context).clearSnackBars();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${removedActivities.length} aktiviteter slettet'),
+        duration: const Duration(seconds: 5),
+        action: SnackBarAction(
+          label: 'Fortryd',
+          onPressed: () {
+            undone = true;
+            for (final a in removedActivities) {
+              cubit.restoreActivity(a);
+            }
+          },
+        ),
+      ),
+    ).closed.then((_) {
+      if (!undone && context.mounted) {
+        for (final a in removedActivities) {
+          cubit.confirmDelete(a.activityId, a);
+        }
+      }
+    });
+  }
+
+  Future<void> _bulkCopy(BuildContext context) async {
+    final cubit = context.read<WeekplanCubit>();
+    final sourceDate = cubit.state.selectedDate;
+
+    final targetDate = await showDatePicker(
+      context: context,
+      initialDate: sourceDate.add(const Duration(days: 1)),
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2100),
+      helpText: 'Kopiér aktiviteter til',
+    );
+    if (targetDate == null || !context.mounted) return;
+
+    final isSameDay = targetDate.year == sourceDate.year &&
+        targetDate.month == sourceDate.month &&
+        targetDate.day == sourceDate.day;
+    if (isSameDay) return;
+
+    final current = cubit.state;
+    if (current is! WeekplanLoaded) return;
+
+    final result = await cubit.copySelectedToDate(
+      activityIds: selectedIds.toList(),
+      targetDate: targetDate,
+    );
+    onDone();
+    if (!context.mounted) return;
+
+    if (result != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(result)),
+      );
+    } else {
+      final formatted = GirafDateUtils.formatDateDDMM(targetDate);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${selectedIds.length} aktiviteter kopieret til $formatted',
+          ),
+        ),
+      );
+    }
+  }
+
+  void _bulkComplete(BuildContext context) {
+    final cubit = context.read<WeekplanCubit>();
+    for (final id in selectedIds) {
+      cubit.toggleActivityStatus(id);
+    }
+    onDone();
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color? color;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveColor = color ?? Theme.of(context).colorScheme.primary;
+    return TextButton.icon(
+      onPressed: onTap,
+      icon: Icon(icon, color: effectiveColor),
+      label: Text(
+        label,
+        style: TextStyle(color: effectiveColor),
+      ),
+    );
+  }
+}
+
+// ── Week overview area ────────────────────────────────────
+
 class _WeekOverviewArea extends StatelessWidget {
   final WeekplanState state;
   final ValueChanged<DateTime> onSelectDay;
@@ -200,17 +473,27 @@ class _WeekOverviewArea extends StatelessWidget {
   }
 }
 
+// ── Day view area ─────────────────────────────────────────
+
 class _ActivityListArea extends StatelessWidget {
   final WeekplanState state;
   final int citizenId;
   final bool isCitizen;
   final int? orgId;
+  final bool isSelecting;
+  final Set<int> selectedIds;
+  final ValueChanged<int> onLongPress;
+  final ValueChanged<int> onToggleSelection;
 
   const _ActivityListArea({
     required this.state,
     required this.citizenId,
     required this.isCitizen,
     this.orgId,
+    required this.isSelecting,
+    required this.selectedIds,
+    required this.onLongPress,
+    required this.onToggleSelection,
   });
 
   @override
@@ -220,12 +503,17 @@ class _ActivityListArea extends StatelessWidget {
       WeekplanError(:final message) => _ErrorWithRetry(message: message),
       WeekplanLoaded(:final activities) when activities.isEmpty =>
         _EmptyDay(selectedDate: state.selectedDate),
-      WeekplanLoaded(:final activities, :final pictogramMedia) => _ActivityList(
+      WeekplanLoaded(:final activities, :final pictogramMedia) =>
+        _ActivityList(
           activities: activities,
           pictogramMedia: pictogramMedia,
           citizenId: citizenId,
           isCitizen: isCitizen,
           orgId: orgId,
+          isSelecting: isSelecting,
+          selectedIds: selectedIds,
+          onLongPress: onLongPress,
+          onToggleSelection: onToggleSelection,
         ),
     };
   }
@@ -288,6 +576,10 @@ class _ActivityList extends StatelessWidget {
   final int citizenId;
   final bool isCitizen;
   final int? orgId;
+  final bool isSelecting;
+  final Set<int> selectedIds;
+  final ValueChanged<int> onLongPress;
+  final ValueChanged<int> onToggleSelection;
 
   const _ActivityList({
     required this.activities,
@@ -295,11 +587,36 @@ class _ActivityList extends StatelessWidget {
     required this.citizenId,
     required this.isCitizen,
     this.orgId,
+    required this.isSelecting,
+    required this.selectedIds,
+    required this.onLongPress,
+    required this.onToggleSelection,
   });
 
   @override
   Widget build(BuildContext context) {
     final cubit = context.read<WeekplanCubit>();
+
+    if (isSelecting) {
+      return ListView.builder(
+        padding: const EdgeInsets.only(top: 8, bottom: 80),
+        itemCount: activities.length,
+        itemBuilder: (context, index) {
+          final activity = activities[index];
+          final media = activity.pictogramId != null
+              ? pictogramMedia[activity.pictogramId!]
+              : null;
+          final isSelected = selectedIds.contains(activity.activityId);
+          return _SelectableActivityItem(
+            activity: activity,
+            imageUrl: media?.imageUrl,
+            isSelected: isSelected,
+            onTap: () => onToggleSelection(activity.activityId),
+          );
+        },
+      );
+    }
+
     return ReorderableListView.builder(
       padding: const EdgeInsets.only(top: 8, bottom: 80),
       onReorder: cubit.reorderActivities,
@@ -325,6 +642,7 @@ class _ActivityList extends StatelessWidget {
           activity: activity,
           imageUrl: media?.imageUrl,
           soundUrl: media?.soundUrl,
+          onLongPress: () => onLongPress(activity.activityId),
           onEdit: () async {
             final dateStr =
                 activity.date.toIso8601String().split('T').first;
@@ -398,5 +716,83 @@ class _ActivityList extends StatelessWidget {
         cubit.confirmDelete(activity.activityId, removed);
       }
     });
+  }
+}
+
+// ── Selectable activity item (selection mode) ─────────────
+
+class _SelectableActivityItem extends StatelessWidget {
+  final Activity activity;
+  final String? imageUrl;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _SelectableActivityItem({
+    required this.activity,
+    this.imageUrl,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Card(
+        color: isSelected
+            ? context.colorScheme.primaryContainer
+            : null,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Checkbox(
+                  value: isSelected,
+                  onChanged: (_) => onTap(),
+                ),
+                const SizedBox(width: 8),
+                // Pictogram thumbnail
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: context.colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: imageUrl != null
+                      ? Image.network(
+                          imageUrl!,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, _, _) => Icon(
+                            Icons.image,
+                            size: 24,
+                            color: context.colorScheme.onPrimaryContainer,
+                          ),
+                        )
+                      : Icon(
+                          Icons.event,
+                          size: 24,
+                          color: context.colorScheme.onPrimaryContainer,
+                        ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    activity.title ?? 'Unavngivet aktivitet',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -86,7 +86,12 @@ class _WeekplanViewState extends State<WeekplanView> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PopScope(
+      canPop: !_isSelecting,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) setState(_exitSelectionMode);
+      },
+      child: Scaffold(
       appBar: _isSelecting
           ? _SelectionAppBar(
               selectedCount: _selectedIds.length,
@@ -189,6 +194,7 @@ class _WeekplanViewState extends State<WeekplanView> {
           );
         },
       ),
+    ),
     );
   }
 }
@@ -383,8 +389,10 @@ class _SelectionActionBar extends StatelessWidget {
     final current = cubit.state;
     if (current is! WeekplanLoaded) return;
 
+    final count = selectedIds.length;
+    final ids = selectedIds.toList();
     final result = await cubit.copySelectedToDate(
-      activityIds: selectedIds.toList(),
+      activityIds: ids,
       targetDate: targetDate,
     );
     onDone();
@@ -398,9 +406,7 @@ class _SelectionActionBar extends StatelessWidget {
       final formatted = GirafDateUtils.formatDateDDMM(targetDate);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(
-            '${selectedIds.length} aktiviteter kopieret til $formatted',
-          ),
+          content: Text('$count aktiviteter kopieret til $formatted'),
         ),
       );
     }
@@ -408,7 +414,18 @@ class _SelectionActionBar extends StatelessWidget {
 
   void _bulkComplete(BuildContext context) {
     final cubit = context.read<WeekplanCubit>();
-    for (final id in selectedIds) {
+    final current = cubit.state;
+    if (current is! WeekplanLoaded) return;
+
+    // Only toggle activities that are not yet completed
+    final idsToComplete = selectedIds.where((id) {
+      final activity = current.activities
+          .where((a) => a.activityId == id)
+          .firstOrNull;
+      return activity != null && !activity.isCompleted;
+    }).toList();
+
+    for (final id in idsToComplete) {
       cubit.toggleActivityStatus(id);
     }
     onDone();

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -263,6 +263,30 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     };
   }
 
+  /// Copy specific activities to a target date.
+  ///
+  /// Returns an error message on failure, or null on success.
+  Future<String?> copySelectedToDate({
+    required List<int> activityIds,
+    required DateTime targetDate,
+  }) async {
+    final current = state;
+    if (current is! WeekplanLoaded) return null;
+
+    final result = await _activityRepository.copyActivities(
+      id: subjectId,
+      isCitizen: isCitizen,
+      sourceDate: current.selectedDate,
+      targetDate: targetDate,
+      activityIds: activityIds,
+    );
+
+    return switch (result) {
+      Left(:final value) => value.message,
+      Right() => null,
+    };
+  }
+
   /// Fetch image and sound URLs for pictograms in the given activities.
   Future<void> _fetchPictogramMedia(List<Activity> activities) async {
     final current = state;

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -12,6 +12,7 @@ class ActivityListItem extends StatefulWidget {
   final VoidCallback onEdit;
   final VoidCallback onDelete;
   final VoidCallback onToggleStatus;
+  final VoidCallback? onLongPress;
   final String? imageUrl;
   final String? soundUrl;
 
@@ -21,6 +22,7 @@ class ActivityListItem extends StatefulWidget {
     required this.onEdit,
     required this.onDelete,
     required this.onToggleStatus,
+    this.onLongPress,
     this.imageUrl,
     this.soundUrl,
   });
@@ -97,6 +99,7 @@ class _ActivityListItemState extends State<ActivityListItem> {
               : context.girafColors.pendingBackground,
           child: InkWell(
             onTap: hasSound ? _togglePlayback : null,
+            onLongPress: widget.onLongPress,
             borderRadius: BorderRadius.circular(12),
             child: Padding(
               padding: const EdgeInsets.all(12),

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -301,5 +301,65 @@ void main() {
       // Icon should switch to day view
       expect(find.byIcon(Icons.view_day), findsOneWidget);
     });
+    testWidgets('long-press enters selection mode with checkboxes',
+        (tester) async {
+      final activities = [
+        Activity(
+          activityId: 1,
+          date: DateTime(2026, 3, 22),
+          title: 'Morgenmad',
+        ),
+        Activity(
+          activityId: 2,
+          date: DateTime(2026, 3, 22),
+          title: 'Frokost',
+        ),
+      ];
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: activities,
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      // Long-press first activity
+      await tester.longPress(find.text('Morgenmad'));
+      await tester.pumpAndSettle();
+
+      // Selection mode indicators
+      expect(find.text('1 valgt'), findsOneWidget);
+      expect(find.text('Vælg alle'), findsOneWidget);
+      expect(find.byType(Checkbox), findsWidgets);
+    });
+
+    testWidgets('close button exits selection mode', (tester) async {
+      final activities = [
+        Activity(
+          activityId: 1,
+          date: DateTime(2026, 3, 22),
+          title: 'Morgenmad',
+        ),
+      ];
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: activities,
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      // Enter selection mode
+      await tester.longPress(find.text('Morgenmad'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 valgt'), findsOneWidget);
+
+      // Close selection
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      // Back to normal mode
+      expect(find.text('1 valgt'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Adds multi-select mode to the weekplan day view. Long-press an activity to enter selection mode, then bulk delete, copy to date, or mark complete.

### Selection mode
- **Enter**: Long-press any activity
- **Select/deselect**: Tap activities (checkboxes shown)
- **Select all**: "Vælg alle" button in selection app bar
- **Exit**: Close button (X) or deselecting the last item

### Bulk actions (bottom action bar)
- **Slet**: Bulk delete with confirmation dialog + undo snackbar (same pattern as single delete)
- **Kopiér**: Copy selected activities to a date via date picker
- **Færdig**: Toggle completion status on all selected activities

### UI changes
- FAB, week selector, and copy-day button are hidden during selection mode
- Selection app bar replaces the normal app bar, showing "{n} valgt"
- Activities render as simplified selectable cards with checkboxes

## Files Changed

| File | Change |
|------|--------|
| `weekplan_view.dart` | Selection state in `_WeekplanViewState`, `_SelectionAppBar`, `_SelectionActionBar`, `_SelectableActivityItem` widgets |
| `activity_list_item.dart` | Added optional `onLongPress` callback |
| `weekplan_cubit.dart` | Added `copySelectedToDate()` for selective copy |
| `weekplan_view_test.dart` | +2 tests (long-press enters selection, close exits) |

## Test plan

- [x] All 222 tests pass (220 baseline + 2 new)
- [x] `dart analyze` reports zero issues
- [ ] Manual: long-press activity → verify selection mode activates
- [ ] Manual: tap to select/deselect → verify checkbox state
- [ ] Manual: "Vælg alle" → verify all selected
- [ ] Manual: bulk delete → confirm dialog → undo snackbar
- [ ] Manual: bulk copy → date picker → success snackbar
- [ ] Manual: bulk complete → verify all toggled
- [ ] Manual: close button → verify exits selection mode

Closes #59