### PR TITLE
feat: recurring activities — create on multiple days at once

### DIFF
--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -133,6 +133,55 @@ public static class ActivityEndpoints
             .Produces(StatusCodes.Status500InternalServerError);
 
 
+        // POST batch-create activities for citizen (recurring)
+        group.MapPost("/batch/to-citizen/{citizenId:int}",
+                async Task<IResult> (int citizenId, CreateBatchActivityDTO dto, IActivityService service,
+                    HttpContext httpContext, CancellationToken ct) =>
+                {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.CreateBatchActivitiesAsync(
+                        new ActivityOwner.Citizen(citizenId), dto, token, ct);
+                    return result.ToHttpResult(v => TypedResults.Created("", v));
+                })
+            .WithName("BatchCreateActivityForCitizen")
+            .WithDescription("Creates activities on multiple dates for a citizen.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Accepts<CreateBatchActivityDTO>("application/json")
+            .Produces<List<ActivityDTO>>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        // POST batch-create activities for grade (recurring)
+        group.MapPost("/batch/to-grade/{gradeId:int}",
+                async Task<IResult> (int gradeId, CreateBatchActivityDTO dto, IActivityService service,
+                    HttpContext httpContext, CancellationToken ct) =>
+                {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.CreateBatchActivitiesAsync(
+                        new ActivityOwner.Grade(gradeId), dto, token, ct);
+                    return result.ToHttpResult(v => TypedResults.Created("", v));
+                })
+            .WithName("BatchCreateActivityForGrade")
+            .WithDescription("Creates activities on multiple dates for a grade.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Accepts<CreateBatchActivityDTO>("application/json")
+            .Produces<List<ActivityDTO>>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+
         group.MapPost("/activity/copy-citizen/{citizenId:int}",
                 async Task<IResult> (int citizenId, DateOnly sourceDate, DateOnly targetDate, List<int> toCopyIds,
                     IActivityService service, HttpContext httpContext, CancellationToken ct) =>

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -144,14 +144,14 @@ public static class ActivityEndpoints
 
                     var result = await service.CreateBatchActivitiesAsync(
                         new ActivityOwner.Citizen(citizenId), dto, token, ct);
-                    return result.ToHttpResult(v => TypedResults.Created("", v));
+                    return result.ToHttpResult(v => TypedResults.Ok(v));
                 })
             .WithName("BatchCreateActivityForCitizen")
             .WithDescription("Creates activities on multiple dates for a citizen.")
             .WithTags("Activities")
             .RequireAuthorization()
             .Accepts<CreateBatchActivityDTO>("application/json")
-            .Produces<List<ActivityDTO>>(StatusCodes.Status201Created)
+            .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)
@@ -168,14 +168,14 @@ public static class ActivityEndpoints
 
                     var result = await service.CreateBatchActivitiesAsync(
                         new ActivityOwner.Grade(gradeId), dto, token, ct);
-                    return result.ToHttpResult(v => TypedResults.Created("", v));
+                    return result.ToHttpResult(v => TypedResults.Ok(v));
                 })
             .WithName("BatchCreateActivityForGrade")
             .WithDescription("Creates activities on multiple dates for a grade.")
             .WithTags("Activities")
             .RequireAuthorization()
             .Accepts<CreateBatchActivityDTO>("application/json")
-            .Produces<List<ActivityDTO>>(StatusCodes.Status201Created)
+            .Produces<List<ActivityDTO>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound)

--- a/backend/GirafAPI/Entities/Activities/DTOs/CreateBatchActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/CreateBatchActivityDTO.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GirafAPI.Entities.Activities.DTOs;
+
+public record CreateBatchActivityDTO
+(
+    [Required] [MinLength(1)] List<DateOnly> Dates,
+    TimeOnly? StartTime,
+    TimeOnly? EndTime,
+    [StringLength(200)] string? Title,
+    int? PictogramId
+);

--- a/backend/GirafAPI/Mapping/ActivityMapping.cs
+++ b/backend/GirafAPI/Mapping/ActivityMapping.cs
@@ -19,6 +19,20 @@ public static class ActivityMapping
         };
     }
 
+    public static Activity ToEntity(this CreateBatchActivityDTO dto, DateOnly date)
+    {
+        return new Activity
+        {
+            Date = date,
+            StartTime = dto.StartTime,
+            EndTime = dto.EndTime,
+            Title = dto.Title,
+            SortOrder = 0,
+            IsCompleted = false,
+            PictogramId = dto.PictogramId
+        };
+    }
+
     public static ActivityDTO ToDTO(this Activity activity)
     {
         return new ActivityDTO(

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -95,6 +95,49 @@ public class ActivityService : IActivityService
         return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
 
+    public async Task<ServiceResult<List<ActivityDTO>>> CreateBatchActivitiesAsync(
+        ActivityOwner owner, CreateBatchActivityDTO dto, string accessToken, CancellationToken ct = default)
+    {
+        if ((dto.StartTime is null) != (dto.EndTime is null))
+            return ServiceResult<List<ActivityDTO>>.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "Start and end time must both be provided or both omitted."));
+
+        if (dto.StartTime is not null && dto.EndTime is not null && dto.EndTime <= dto.StartTime)
+            return ServiceResult<List<ActivityDTO>>.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "End time must be after start time."));
+
+        var ownerResult = await ValidateOwnerAsync(owner, accessToken, ct);
+        if (ownerResult is not null)
+            return ServiceResult<List<ActivityDTO>>.Fail(ownerResult);
+
+        if (dto.PictogramId is not null)
+        {
+            var picResult = await _coreClient.ValidatePictogramAsync(dto.PictogramId.Value, accessToken, ct);
+            if (picResult is not CoreValidationResult.Valid)
+                return ServiceResult<List<ActivityDTO>>.Fail(ToCoreError(picResult, "Pictogram"));
+        }
+
+        var created = new List<ActivityDTO>();
+        foreach (var date in dto.Dates)
+        {
+            var activity = dto.ToEntity(date);
+            owner.ApplyTo(activity);
+
+            var maxOrder = await _db.Activities
+                .Where(owner.ToFilter())
+                .Where(a => a.Date == date)
+                .MaxAsync(a => (int?)a.SortOrder, ct) ?? -1;
+            activity.SortOrder = maxOrder + 1;
+
+            _db.Activities.Add(activity);
+            await _db.SaveChangesAsync(ct);
+
+            created.Add(activity.ToDTO());
+        }
+
+        return ServiceResult<List<ActivityDTO>>.Success(created);
+    }
+
     public async Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default)
     {

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -117,7 +117,7 @@ public class ActivityService : IActivityService
                 return ServiceResult<List<ActivityDTO>>.Fail(ToCoreError(picResult, "Pictogram"));
         }
 
-        var created = new List<ActivityDTO>();
+        var activities = new List<Activity>();
         foreach (var date in dto.Dates)
         {
             var activity = dto.ToEntity(date);
@@ -127,15 +127,18 @@ public class ActivityService : IActivityService
                 .Where(owner.ToFilter())
                 .Where(a => a.Date == date)
                 .MaxAsync(a => (int?)a.SortOrder, ct) ?? -1;
-            activity.SortOrder = maxOrder + 1;
+            // Account for other activities being added for the same date in this batch
+            var batchOffset = activities.Count(a => a.Date == date);
+            activity.SortOrder = maxOrder + 1 + batchOffset;
 
             _db.Activities.Add(activity);
-            await _db.SaveChangesAsync(ct);
-
-            created.Add(activity.ToDTO());
+            activities.Add(activity);
         }
 
-        return ServiceResult<List<ActivityDTO>>.Success(created);
+        await _db.SaveChangesAsync(ct);
+
+        return ServiceResult<List<ActivityDTO>>.Success(
+            activities.Select(a => a.ToDTO()).ToList());
     }
 
     public async Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(

--- a/backend/GirafAPI/Services/IActivityService.cs
+++ b/backend/GirafAPI/Services/IActivityService.cs
@@ -11,6 +11,9 @@ public interface IActivityService
     Task<ServiceResult<ActivityDTO>> CreateActivityAsync(
         ActivityOwner owner, CreateActivityDTO dto, string accessToken, CancellationToken ct = default);
 
+    Task<ServiceResult<List<ActivityDTO>>> CreateBatchActivitiesAsync(
+        ActivityOwner owner, CreateBatchActivityDTO dto, string accessToken, CancellationToken ct = default);
+
     Task<ServiceResult<ActivityDTO>> UpdateActivityAsync(
         int id, UpdateActivityDTO dto, string accessToken, CancellationToken ct = default);
 

--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -56,6 +56,23 @@ class ActivityRepositoryImpl implements ActivityRepository {
   }
 
   @override
+  Future<Either<ActivityFailure, List<Activity>>> batchCreateActivities({
+    required int id,
+    required bool isCitizen,
+    required Map<String, dynamic> data,
+  }) async {
+    try {
+      final activities = isCitizen
+          ? await _apiService.batchCreateForCitizen(id, data)
+          : await _apiService.batchCreateForGrade(id, data);
+      return Right(activities);
+    } catch (e, stackTrace) {
+      logServerError(_log, 'Failed to batch-create activities', e, stackTrace);
+      return Left(const CreateActivityFailure());
+    }
+  }
+
+  @override
   Future<Either<ActivityFailure, Activity>> updateActivity(
     int activityId,
     Map<String, dynamic> data,

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -30,6 +30,10 @@ final class ActivityFormData with EquatableMixin {
   /// The activity being edited, or null for new activities.
   final Activity? existingActivity;
 
+  /// Weekdays to repeat on (1=Monday..7=Sunday). Empty = single date only.
+  /// Only used when creating new activities.
+  final Set<int> repeatDays;
+
   const ActivityFormData({
     this.title = '',
     this.hasTime = false,
@@ -37,6 +41,7 @@ final class ActivityFormData with EquatableMixin {
     this.endTime = const (hour: 9, minute: 0),
     required this.date,
     this.existingActivity,
+    this.repeatDays = const {},
   });
 
   /// Whether this is an edit (vs. create) operation.
@@ -50,6 +55,7 @@ final class ActivityFormData with EquatableMixin {
     DateTime? date,
     Activity? existingActivity,
     bool clearExistingActivity = false,
+    Set<int>? repeatDays,
   }) {
     return ActivityFormData(
       title: title ?? this.title,
@@ -60,12 +66,13 @@ final class ActivityFormData with EquatableMixin {
       existingActivity: clearExistingActivity
           ? null
           : (existingActivity ?? this.existingActivity),
+      repeatDays: repeatDays ?? this.repeatDays,
     );
   }
 
   @override
   List<Object?> get props =>
-      [title, hasTime, startTime, endTime, date, existingActivity];
+      [title, hasTime, startTime, endTime, date, existingActivity, repeatDays];
 }
 
 // ── Sub-state: Pictogram selection ─────────────────────────

--- a/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
@@ -19,6 +19,13 @@ abstract interface class ActivityRepository {
     required Map<String, dynamic> data,
   });
 
+  /// Create activities on multiple dates for a citizen or grade.
+  Future<Either<ActivityFailure, List<Activity>>> batchCreateActivities({
+    required int id,
+    required bool isCitizen,
+    required Map<String, dynamic> data,
+  });
+
   /// Update an existing activity.
   Future<Either<ActivityFailure, Activity>> updateActivity(
     int activityId,

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -63,6 +63,26 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     _emitReady(form: state.form.copyWith(date: date));
   }
 
+  void toggleRepeatDay(int weekday) {
+    final current = Set<int>.from(state.form.repeatDays);
+    if (current.contains(weekday)) {
+      current.remove(weekday);
+    } else {
+      current.add(weekday);
+    }
+    _emitReady(form: state.form.copyWith(repeatDays: current));
+  }
+
+  void setRepeatWeekdays() {
+    _emitReady(
+      form: state.form.copyWith(repeatDays: const {1, 2, 3, 4, 5}),
+    );
+  }
+
+  void clearRepeatDays() {
+    _emitReady(form: state.form.copyWith(repeatDays: const {}));
+  }
+
   void toggleHasTime() {
     _emitReady(form: state.form.copyWith(hasTime: !state.form.hasTime));
   }
@@ -248,42 +268,78 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
       search: s.search,
     ));
 
-    final data = {
-      'date': GirafDateUtils.formatQueryDate(s.form.date),
-      if (s.form.hasTime)
-        'startTime': formatTimeValueForApi(s.form.startTime),
-      if (s.form.hasTime)
-        'endTime': formatTimeValueForApi(s.form.endTime),
-      'title': s.form.title,
-      'pictogramId': s.selection.id,
-    };
-
-    final Either<ActivityFailure, Activity> result;
     final existing = s.form.existingActivity;
-    if (existing != null) {
-      result = await _activityRepository.updateActivity(
-          existing.activityId, data);
-    } else {
-      result = await _activityRepository.createActivity(
+    final useBatch = existing == null && s.form.repeatDays.isNotEmpty;
+
+    bool failed = false;
+
+    if (useBatch) {
+      // Batch create: compute dates from the current week matching repeatDays
+      final weekDates = GirafDateUtils.getWeekDates(s.form.date);
+      final dates = weekDates
+          .where((d) => s.form.repeatDays.contains(d.weekday))
+          .map(GirafDateUtils.formatQueryDate)
+          .toList();
+
+      final batchData = {
+        'dates': dates,
+        if (s.form.hasTime)
+          'startTime': formatTimeValueForApi(s.form.startTime),
+        if (s.form.hasTime)
+          'endTime': formatTimeValueForApi(s.form.endTime),
+        'title': s.form.title,
+        'pictogramId': s.selection.id,
+      };
+
+      final result = await _activityRepository.batchCreateActivities(
         id: subjectId,
         isCitizen: isCitizen,
-        data: data,
+        data: batchData,
       );
+      failed = result.isLeft();
+      if (failed) {
+        _emitReady(error: result.getLeft().toNullable()?.message);
+        return false;
+      }
+    } else {
+      final data = {
+        'date': GirafDateUtils.formatQueryDate(s.form.date),
+        if (s.form.hasTime)
+          'startTime': formatTimeValueForApi(s.form.startTime),
+        if (s.form.hasTime)
+          'endTime': formatTimeValueForApi(s.form.endTime),
+        'title': s.form.title,
+        'pictogramId': s.selection.id,
+      };
+
+      final Either<ActivityFailure, Activity> result;
+      if (existing != null) {
+        result = await _activityRepository.updateActivity(
+            existing.activityId, data);
+      } else {
+        result = await _activityRepository.createActivity(
+          id: subjectId,
+          isCitizen: isCitizen,
+          data: data,
+        );
+      }
+
+      switch (result) {
+        case Left(:final value):
+          _emitReady(error: value.message);
+          return false;
+        case Right():
+          break;
+      }
     }
 
-    switch (result) {
-      case Left(:final value):
-        _emitReady(error: value.message);
-        return false;
-      case Right():
-        emit(ActivityFormSaved(
-          form: s.form,
-          selection: s.selection,
-          creation: s.creation,
-          search: s.search,
-        ));
-        return true;
-    }
+    emit(ActivityFormSaved(
+      form: s.form,
+      selection: s.selection,
+      creation: s.creation,
+      search: s.search,
+    ));
+    return true;
   }
 
   // ── Helpers ──────────────────────────────────────────────

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -271,8 +271,6 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     final existing = s.form.existingActivity;
     final useBatch = existing == null && s.form.repeatDays.isNotEmpty;
 
-    bool failed = false;
-
     if (useBatch) {
       // Batch create: compute dates from the current week matching repeatDays
       final weekDates = GirafDateUtils.getWeekDates(s.form.date);
@@ -296,10 +294,12 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         isCitizen: isCitizen,
         data: batchData,
       );
-      failed = result.isLeft();
-      if (failed) {
-        _emitReady(error: result.getLeft().toNullable()?.message);
-        return false;
+      switch (result) {
+        case Left(:final value):
+          _emitReady(error: value.message);
+          return false;
+        case Right():
+          break;
       }
     } else {
       final data = {

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -71,6 +71,15 @@ class ActivityFormView extends StatelessWidget {
                     },
                   ),
                   const SizedBox(height: 16),
+                  // Repeat selector (only for new activities)
+                  if (!state.isEditing)
+                    _RepeatDaySelector(
+                      selectedDays: state.form.repeatDays,
+                      onToggleDay: cubit.toggleRepeatDay,
+                      onSelectWeekdays: cubit.setRepeatWeekdays,
+                      onClear: cubit.clearRepeatDays,
+                    ),
+                  if (!state.isEditing) const SizedBox(height: 16),
                   // Time toggle
                   SwitchListTile(
                     title: const Text('Angiv tidspunkt'),
@@ -239,6 +248,113 @@ class _DatePicker extends StatelessWidget {
         child: Text(
           '$dayName $formatted',
           style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}
+
+class _RepeatDaySelector extends StatelessWidget {
+  final Set<int> selectedDays;
+  final ValueChanged<int> onToggleDay;
+  final VoidCallback onSelectWeekdays;
+  final VoidCallback onClear;
+
+  const _RepeatDaySelector({
+    required this.selectedDays,
+    required this.onToggleDay,
+    required this.onSelectWeekdays,
+    required this.onClear,
+  });
+
+  static const _dayLabels = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              'Gentag',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const Spacer(),
+            if (selectedDays.isEmpty)
+              TextButton(
+                onPressed: onSelectWeekdays,
+                child: const Text('Hverdage'),
+              )
+            else
+              TextButton(
+                onPressed: onClear,
+                child: const Text('Ryd'),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: List.generate(7, (index) {
+            final weekday = index + 1;
+            final isSelected = selectedDays.contains(weekday);
+            return _DayChip(
+              label: _dayLabels[index],
+              isSelected: isSelected,
+              onTap: () => onToggleDay(weekday),
+            );
+          }),
+        ),
+        if (selectedDays.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              'Oprettes på ${selectedDays.length} dage denne uge',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _DayChip extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _DayChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: isSelected
+              ? Theme.of(context).colorScheme.primary
+              : Theme.of(context).colorScheme.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: isSelected
+                ? Theme.of(context).colorScheme.onPrimary
+                : Theme.of(context).colorScheme.onSurface,
+          ),
         ),
       ),
     );

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -79,6 +79,37 @@ class ActivityApiService implements TokenConsumer {
     return Activity.fromJson(response.data! as Map<String, dynamic>);
   }
 
+  // Batch-create activities on multiple dates
+  Future<List<Activity>> batchCreateForCitizen(
+    int citizenId,
+    Map<String, dynamic> data,
+  ) async {
+    final response = await _dio.post(
+      '/weekplan/batch/to-citizen/$citizenId',
+      data: data,
+    );
+    final list = response.data as List;
+    return list
+        .whereType<Map<String, dynamic>>()
+        .map(Activity.fromJson)
+        .toList();
+  }
+
+  Future<List<Activity>> batchCreateForGrade(
+    int gradeId,
+    Map<String, dynamic> data,
+  ) async {
+    final response = await _dio.post(
+      '/weekplan/batch/to-grade/$gradeId',
+      data: data,
+    );
+    final list = response.data as List;
+    return list
+        .whereType<Map<String, dynamic>>()
+        .map(Activity.fromJson)
+        .toList();
+  }
+
   Future<Activity> updateActivity(
     int activityId,
     Map<String, dynamic> data,

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -115,6 +115,80 @@ void main() {
     );
   });
 
+  group('toggleRepeatDay', () {
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'adds weekday to repeatDays',
+      build: buildCubit,
+      act: (cubit) => cubit.toggleRepeatDay(1),
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          {1},
+        ),
+      ],
+    );
+
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'removes weekday from repeatDays when already present',
+      build: buildCubit,
+      act: (cubit) {
+        cubit.toggleRepeatDay(1);
+        cubit.toggleRepeatDay(1);
+      },
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          {1},
+        ),
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          <int>{},
+        ),
+      ],
+    );
+  });
+
+  group('setRepeatWeekdays', () {
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'sets Mon-Fri',
+      build: buildCubit,
+      act: (cubit) => cubit.setRepeatWeekdays(),
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          {1, 2, 3, 4, 5},
+        ),
+      ],
+    );
+  });
+
+  group('clearRepeatDays', () {
+    blocTest<ActivityFormCubit, ActivityFormState>(
+      'clears all repeat days',
+      build: buildCubit,
+      act: (cubit) {
+        cubit.setRepeatWeekdays();
+        cubit.clearRepeatDays();
+      },
+      expect: () => [
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          {1, 2, 3, 4, 5},
+        ),
+        isA<ActivityFormReady>().having(
+          (s) => s.form.repeatDays,
+          'repeatDays',
+          <int>{},
+        ),
+      ],
+    );
+  });
+
   group('setStartTime', () {
     blocTest<ActivityFormCubit, ActivityFormState>(
       'emits updated ActivityFormReady with new start time',


### PR DESCRIPTION
## Summary

Adds the ability to create an activity on multiple days of the week in a single action. When adding a new activity, users can select which days of the current week to repeat it on via a day selector with circular chips (Man-Søn) and a "Hverdage" (weekdays) shortcut.

### Backend
- New `CreateBatchActivityDTO` with `List<DateOnly> Dates` instead of single `Date`
- `CreateBatchActivitiesAsync` service method — validates once, creates one activity per date with auto-sorted order
- `POST /weekplan/batch/to-citizen/{citizenId}` and `POST /weekplan/batch/to-grade/{gradeId}` endpoints

### Frontend
- `_RepeatDaySelector` widget with 7 tappable day chips + "Hverdage"/"Ryd" buttons
- `ActivityFormData.repeatDays` — `Set<int>` of weekdays (1-7)
- Cubit: `toggleRepeatDay`, `setRepeatWeekdays`, `clearRepeatDays` methods
- `save()` uses batch endpoint when `repeatDays` is non-empty; each created activity is independent
- Repeat selector hidden when editing existing activities

## Test plan

- [x] Backend: 54 tests pass, 0 warnings
- [x] Frontend: 222 tests pass, `dart analyze` zero issues
- [ ] Manual: create activity → select Man/Ons/Fre → save → verify 3 activities created
- [ ] Manual: tap "Hverdage" → verify Mon-Fri selected
- [ ] Manual: tap "Ryd" → verify all deselected, single-day create
- [ ] Manual: edit existing activity → verify repeat selector not shown
- [ ] Manual: verify each created activity is independent (edit one, others unchanged)

Closes #56