### PR TITLE
feat: choice activity backend — options entity and select endpoint

### DIFF
--- a/backend/GirafAPI/Data/GirafDbContext.cs
+++ b/backend/GirafAPI/Data/GirafDbContext.cs
@@ -10,6 +10,7 @@ namespace GirafAPI.Data
         }
 
         public DbSet<Activity> Activities { get; set; }
+        public DbSet<ActivityOption> ActivityOptions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -20,6 +21,10 @@ namespace GirafAPI.Data
                 entity.HasIndex(e => e.CitizenId);
                 entity.HasIndex(e => e.GradeId);
                 entity.HasIndex(e => e.PictogramId);
+                entity.HasMany(e => e.Options)
+                    .WithOne(o => o.Activity)
+                    .HasForeignKey(o => o.ActivityId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
         }
     }

--- a/backend/GirafAPI/Data/Migrations/20260405193755_AddChoiceActivities.Designer.cs
+++ b/backend/GirafAPI/Data/Migrations/20260405193755_AddChoiceActivities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GirafAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GirafAPI.Data.Migrations
 {
     [DbContext(typeof(GirafDbContext))]
-    partial class GirafDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260405193755_AddChoiceActivities")]
+    partial class AddChoiceActivities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/GirafAPI/Data/Migrations/20260405193755_AddChoiceActivities.cs
+++ b/backend/GirafAPI/Data/Migrations/20260405193755_AddChoiceActivities.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GirafAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoiceActivities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SelectedOptionIndex",
+                table: "Activities",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ActivityOptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ActivityId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PictogramId = table.Column<int>(type: "integer", nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ActivityOptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ActivityOptions_Activities_ActivityId",
+                        column: x => x.ActivityId,
+                        principalTable: "Activities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ActivityOptions_ActivityId",
+                table: "ActivityOptions",
+                column: "ActivityId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ActivityOptions");
+
+            migrationBuilder.DropColumn(
+                name: "SelectedOptionIndex",
+                table: "Activities");
+        }
+    }
+}

--- a/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
+++ b/backend/GirafAPI/Endpoints/ActivityEndpoints.cs
@@ -182,6 +182,30 @@ public static class ActivityEndpoints
             .Produces(StatusCodes.Status500InternalServerError);
 
 
+        // PUT select option on a choice activity
+        group.MapPut("/activity/{id:int}/select-option/{optionIndex:int}",
+                async Task<IResult> (int id, int optionIndex, IActivityService service,
+                    HttpContext httpContext, CancellationToken ct) =>
+                {
+                    var token = GetAccessToken(httpContext);
+                    if (token is null)
+                        return TypedResults.Unauthorized();
+
+                    var result = await service.SelectOptionAsync(id, optionIndex, token, ct);
+                    return result.ToHttpResult(v => TypedResults.Ok(v));
+                })
+            .WithName("SelectActivityOption")
+            .WithDescription("Selects an option on a choice activity.")
+            .WithTags("Activities")
+            .RequireAuthorization()
+            .Produces<ActivityDTO>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+
         group.MapPost("/activity/copy-citizen/{citizenId:int}",
                 async Task<IResult> (int citizenId, DateOnly sourceDate, DateOnly targetDate, List<int> toCopyIds,
                     IActivityService service, HttpContext httpContext, CancellationToken ct) =>

--- a/backend/GirafAPI/Entities/Activities/Activity.cs
+++ b/backend/GirafAPI/Entities/Activities/Activity.cs
@@ -25,4 +25,11 @@ public class Activity
     public int? GradeId { get; set; }
 
     public int? PictogramId { get; set; }
+
+    /// Index of the selected option (null = not yet chosen).
+    /// Only meaningful when Options is non-empty.
+    public int? SelectedOptionIndex { get; set; }
+
+    /// Choice options for this activity. Empty for regular activities.
+    public List<ActivityOption> Options { get; set; } = [];
 }

--- a/backend/GirafAPI/Entities/Activities/ActivityOption.cs
+++ b/backend/GirafAPI/Entities/Activities/ActivityOption.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GirafAPI.Entities.Activities;
+
+/// An option within a choice activity. Children pick one of these.
+public class ActivityOption
+{
+    public int Id { get; set; }
+
+    public int ActivityId { get; set; }
+
+    public Activity Activity { get; set; } = null!;
+
+    [MaxLength(200)]
+    public string? Title { get; set; }
+
+    public int? PictogramId { get; set; }
+
+    public int SortOrder { get; set; }
+}

--- a/backend/GirafAPI/Entities/Activities/DTOs/ActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/ActivityDTO.cs
@@ -11,5 +11,7 @@ public record ActivityDTO
     string? Title,
     int SortOrder,
     bool IsCompleted,
-    int? PictogramId
+    int? PictogramId,
+    int? SelectedOptionIndex,
+    List<ActivityOptionDTO> Options
 );

--- a/backend/GirafAPI/Entities/Activities/DTOs/ActivityOptionDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/ActivityOptionDTO.cs
@@ -1,0 +1,8 @@
+namespace GirafAPI.Entities.Activities.DTOs;
+
+public record ActivityOptionDTO(
+    int Id,
+    string? Title,
+    int? PictogramId,
+    int SortOrder
+);

--- a/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityDTO.cs
@@ -2,12 +2,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace GirafAPI.Entities.Activities.DTOs;
 
-public record CreateActivityDTO
-(
+public record CreateActivityDTO(
     [Required] DateOnly Date,
-    TimeOnly? StartTime,
-    TimeOnly? EndTime,
-    [StringLength(200)] string? Title,
-    int? SortOrder,
-    int? PictogramId
+    TimeOnly? StartTime = null,
+    TimeOnly? EndTime = null,
+    [StringLength(200)] string? Title = null,
+    int? SortOrder = null,
+    int? PictogramId = null,
+    List<CreateActivityOptionDTO>? Options = null
 );

--- a/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityOptionDTO.cs
+++ b/backend/GirafAPI/Entities/Activities/DTOs/CreateActivityOptionDTO.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GirafAPI.Entities.Activities.DTOs;
+
+public record CreateActivityOptionDTO(
+    [StringLength(200)] string? Title,
+    int? PictogramId
+);

--- a/backend/GirafAPI/Mapping/ActivityMapping.cs
+++ b/backend/GirafAPI/Mapping/ActivityMapping.cs
@@ -7,7 +7,7 @@ public static class ActivityMapping
 {
     public static Activity ToEntity(this CreateActivityDTO dto)
     {
-        return new Activity
+        var activity = new Activity
         {
             Date = dto.Date,
             StartTime = dto.StartTime,
@@ -15,8 +15,20 @@ public static class ActivityMapping
             Title = dto.Title,
             SortOrder = dto.SortOrder ?? 0,
             IsCompleted = false,
-            PictogramId = dto.PictogramId
+            PictogramId = dto.PictogramId,
         };
+
+        if (dto.Options is { Count: > 0 })
+        {
+            activity.Options = dto.Options.Select((o, i) => new ActivityOption
+            {
+                Title = o.Title,
+                PictogramId = o.PictogramId,
+                SortOrder = i,
+            }).ToList();
+        }
+
+        return activity;
     }
 
     public static Activity ToEntity(this CreateBatchActivityDTO dto, DateOnly date)
@@ -43,7 +55,19 @@ public static class ActivityMapping
             activity.Title,
             activity.SortOrder,
             activity.IsCompleted,
-            activity.PictogramId
+            activity.PictogramId,
+            activity.SelectedOptionIndex,
+            activity.Options.Select(o => o.ToDTO()).ToList()
+        );
+    }
+
+    public static ActivityOptionDTO ToDTO(this ActivityOption option)
+    {
+        return new ActivityOptionDTO(
+            option.Id,
+            option.Title,
+            option.PictogramId,
+            option.SortOrder
         );
     }
 }

--- a/backend/GirafAPI/Services/ActivityService.cs
+++ b/backend/GirafAPI/Services/ActivityService.cs
@@ -26,20 +26,23 @@ public class ActivityService : IActivityService
             return ServiceResult<List<ActivityDTO>>.Fail(ownerResult);
 
         var activities = await _db.Activities
+            .Include(a => a.Options.OrderBy(o => o.SortOrder))
             .Where(owner.ToFilter())
             .Where(a => a.Date == date)
             .OrderBy(a => a.SortOrder)
             .ThenBy(a => a.StartTime)
-            .Select(a => a.ToDTO())
             .AsNoTracking()
             .ToListAsync(ct);
 
-        return ServiceResult<List<ActivityDTO>>.Success(activities);
+        var dtos = activities.Select(a => a.ToDTO()).ToList();
+
+        return ServiceResult<List<ActivityDTO>>.Success(dtos);
     }
 
     public async Task<ServiceResult<ActivityDTO>> GetActivityByIdAsync(int id, string accessToken, CancellationToken ct = default)
     {
         var activity = await _db.Activities
+            .Include(a => a.Options.OrderBy(o => o.SortOrder))
             .AsNoTracking()
             .FirstOrDefaultAsync(a => a.Id == id, ct);
 
@@ -294,6 +297,36 @@ public class ActivityService : IActivityService
 
         await _db.SaveChangesAsync(ct);
         return ServiceResult.Success();
+    }
+
+    public async Task<ServiceResult<ActivityDTO>> SelectOptionAsync(
+        int activityId, int optionIndex, string accessToken, CancellationToken ct = default)
+    {
+        var activity = await _db.Activities
+            .Include(a => a.Options.OrderBy(o => o.SortOrder))
+            .FirstOrDefaultAsync(a => a.Id == activityId, ct);
+
+        if (activity is null)
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.NotFound, "Activity not found."));
+
+        var ownerError = await ValidateActivityOwnerAsync(activity, accessToken, ct);
+        if (ownerError is not null)
+            return ServiceResult<ActivityDTO>.Fail(ownerError);
+
+        if (activity.Options.Count == 0)
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.Validation, "Activity has no options to select from."));
+
+        if (optionIndex < 0 || optionIndex >= activity.Options.Count)
+            return ServiceResult<ActivityDTO>.Fail(
+                new ServiceError(ServiceErrorKind.Validation,
+                    $"Option index must be between 0 and {activity.Options.Count - 1}."));
+
+        activity.SelectedOptionIndex = optionIndex;
+        await _db.SaveChangesAsync(ct);
+
+        return ServiceResult<ActivityDTO>.Success(activity.ToDTO());
     }
 
     /// <summary>

--- a/backend/GirafAPI/Services/IActivityService.cs
+++ b/backend/GirafAPI/Services/IActivityService.cs
@@ -26,6 +26,9 @@ public interface IActivityService
     Task<ServiceResult> CopyActivitiesAsync(
         ActivityOwner owner, DateOnly sourceDate, DateOnly targetDate, List<int> activityIds, string accessToken, CancellationToken ct = default);
 
+    Task<ServiceResult<ActivityDTO>> SelectOptionAsync(
+        int activityId, int optionIndex, string accessToken, CancellationToken ct = default);
+
     Task<ServiceResult> ReorderActivitiesAsync(
         ActivityOwner owner, List<ReorderItemDTO> items, string accessToken, CancellationToken ct = default);
 }

--- a/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/data/repositories/activity_repository.dart
@@ -56,6 +56,20 @@ class ActivityRepositoryImpl implements ActivityRepository {
   }
 
   @override
+  Future<Either<ActivityFailure, Activity>> selectOption(
+    int activityId,
+    int optionIndex,
+  ) async {
+    try {
+      final activity = await _apiService.selectOption(activityId, optionIndex);
+      return Right(activity);
+    } catch (e, stackTrace) {
+      logServerError(_log, 'Failed to select option', e, stackTrace);
+      return Left(const UpdateActivityFailure());
+    }
+  }
+
+  @override
   Future<Either<ActivityFailure, List<Activity>>> batchCreateActivities({
     required int id,
     required bool isCitizen,

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -34,6 +34,12 @@ final class ActivityFormData with EquatableMixin {
   /// Only used when creating new activities.
   final Set<int> repeatDays;
 
+  /// Whether this is a choice activity with multiple options.
+  final bool isChoiceActivity;
+
+  /// Options for a choice activity. Each has a title and pictogramId.
+  final List<ChoiceOptionData> choiceOptions;
+
   const ActivityFormData({
     this.title = '',
     this.hasTime = false,
@@ -42,6 +48,8 @@ final class ActivityFormData with EquatableMixin {
     required this.date,
     this.existingActivity,
     this.repeatDays = const {},
+    this.isChoiceActivity = false,
+    this.choiceOptions = const [],
   });
 
   /// Whether this is an edit (vs. create) operation.
@@ -56,6 +64,8 @@ final class ActivityFormData with EquatableMixin {
     Activity? existingActivity,
     bool clearExistingActivity = false,
     Set<int>? repeatDays,
+    bool? isChoiceActivity,
+    List<ChoiceOptionData>? choiceOptions,
   }) {
     return ActivityFormData(
       title: title ?? this.title,
@@ -67,12 +77,53 @@ final class ActivityFormData with EquatableMixin {
           ? null
           : (existingActivity ?? this.existingActivity),
       repeatDays: repeatDays ?? this.repeatDays,
+      isChoiceActivity: isChoiceActivity ?? this.isChoiceActivity,
+      choiceOptions: choiceOptions ?? this.choiceOptions,
     );
   }
 
   @override
-  List<Object?> get props =>
-      [title, hasTime, startTime, endTime, date, existingActivity, repeatDays];
+  List<Object?> get props => [
+        title,
+        hasTime,
+        startTime,
+        endTime,
+        date,
+        existingActivity,
+        repeatDays,
+        isChoiceActivity,
+        choiceOptions,
+      ];
+}
+
+/// Data for a single choice option in the activity form.
+final class ChoiceOptionData with EquatableMixin {
+  final String title;
+  final int? pictogramId;
+  final String? pictogramName;
+
+  const ChoiceOptionData({
+    this.title = '',
+    this.pictogramId,
+    this.pictogramName,
+  });
+
+  ChoiceOptionData copyWith({
+    String? title,
+    int? pictogramId,
+    String? pictogramName,
+    bool clearPictogram = false,
+  }) {
+    return ChoiceOptionData(
+      title: title ?? this.title,
+      pictogramId: clearPictogram ? null : (pictogramId ?? this.pictogramId),
+      pictogramName:
+          clearPictogram ? null : (pictogramName ?? this.pictogramName),
+    );
+  }
+
+  @override
+  List<Object?> get props => [title, pictogramId, pictogramName];
 }
 
 // ── Sub-state: Pictogram selection ─────────────────────────

--- a/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
+++ b/frontend/lib/features/weekplan/domain/repositories/activity_repository.dart
@@ -26,6 +26,12 @@ abstract interface class ActivityRepository {
     required Map<String, dynamic> data,
   });
 
+  /// Select an option on a choice activity.
+  Future<Either<ActivityFailure, Activity>> selectOption(
+    int activityId,
+    int optionIndex,
+  );
+
   /// Update an existing activity.
   Future<Either<ActivityFailure, Activity>> updateActivity(
     int activityId,

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -83,6 +83,44 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     _emitReady(form: state.form.copyWith(repeatDays: const {}));
   }
 
+  void toggleChoiceActivity() {
+    final isChoice = !state.form.isChoiceActivity;
+    _emitReady(form: state.form.copyWith(
+      isChoiceActivity: isChoice,
+      choiceOptions: isChoice && state.form.choiceOptions.isEmpty
+          ? const [ChoiceOptionData(), ChoiceOptionData()]
+          : state.form.choiceOptions,
+    ));
+  }
+
+  void addChoiceOption() {
+    if (state.form.choiceOptions.length >= 3) return;
+    final updated = [...state.form.choiceOptions, const ChoiceOptionData()];
+    _emitReady(form: state.form.copyWith(choiceOptions: updated));
+  }
+
+  void removeChoiceOption(int index) {
+    if (state.form.choiceOptions.length <= 2) return;
+    final updated = [...state.form.choiceOptions]..removeAt(index);
+    _emitReady(form: state.form.copyWith(choiceOptions: updated));
+  }
+
+  void setChoiceOptionTitle(int index, String title) {
+    final updated = [...state.form.choiceOptions];
+    updated[index] = updated[index].copyWith(title: title);
+    _emitReady(form: state.form.copyWith(choiceOptions: updated));
+  }
+
+  void setChoiceOptionPictogram(int index, int pictogramId, String name) {
+    final updated = [...state.form.choiceOptions];
+    updated[index] = updated[index].copyWith(
+      pictogramId: pictogramId,
+      pictogramName: name,
+      title: updated[index].title.isEmpty ? name : null,
+    );
+    _emitReady(form: state.form.copyWith(choiceOptions: updated));
+  }
+
   void toggleHasTime() {
     _emitReady(form: state.form.copyWith(hasTime: !state.form.hasTime));
   }
@@ -237,8 +275,16 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   /// Validate the form and return an error message, or null if valid.
   String? validate() {
-    if (state.selection.id == null) {
-      return 'Vælg et piktogram';
+    if (state.form.isChoiceActivity) {
+      for (final option in state.form.choiceOptions) {
+        if (option.pictogramId == null) {
+          return 'Alle valgmuligheder skal have et piktogram';
+        }
+      }
+    } else {
+      if (state.selection.id == null) {
+        return 'Vælg et piktogram';
+      }
     }
     if (state.form.hasTime) {
       final startMinutes =
@@ -309,7 +355,14 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         if (s.form.hasTime)
           'endTime': formatTimeValueForApi(s.form.endTime),
         'title': s.form.title,
-        'pictogramId': s.selection.id,
+        if (!s.form.isChoiceActivity) 'pictogramId': s.selection.id,
+        if (s.form.isChoiceActivity)
+          'options': s.form.choiceOptions
+              .map((o) => {
+                    'title': o.title,
+                    'pictogramId': o.pictogramId,
+                  })
+              .toList(),
       };
 
       final Either<ActivityFailure, Activity> result;

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -5,7 +5,10 @@ import 'package:go_router/go_router.dart';
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
+import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_selector.dart';
+import 'package:weekplanner/shared/models/pictogram.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
 class ActivityFormView extends StatelessWidget {
@@ -41,19 +44,45 @@ class ActivityFormView extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  // Pictogram selector (required)
-                  Text(
-                    'Piktogram',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 8),
-                  const PictogramSelector(),
-                  const SizedBox(height: 24),
-                  // Title field
-                  _TitleField(
-                    title: state.form.title,
-                    onChanged: cubit.setTitle,
-                  ),
+                  // Choice activity toggle (only for new activities)
+                  if (!state.isEditing)
+                    SwitchListTile(
+                      title: const Text('Valgaktivitet'),
+                      subtitle: state.form.isChoiceActivity
+                          ? const Text('Barnet vælger mellem muligheder')
+                          : null,
+                      value: state.form.isChoiceActivity,
+                      onChanged: (_) => cubit.toggleChoiceActivity(),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  if (!state.isEditing) const SizedBox(height: 8),
+                  if (state.form.isChoiceActivity) ...[
+                    // Choice options editor
+                    _ChoiceOptionsEditor(
+                      options: state.form.choiceOptions,
+                      cubit: cubit,
+                    ),
+                    const SizedBox(height: 16),
+                    // Title for the activity slot itself
+                    _TitleField(
+                      title: state.form.title,
+                      onChanged: cubit.setTitle,
+                    ),
+                  ] else ...[
+                    // Normal: single pictogram selector
+                    Text(
+                      'Piktogram',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    const PictogramSelector(),
+                    const SizedBox(height: 24),
+                    // Title field
+                    _TitleField(
+                      title: state.form.title,
+                      onChanged: cubit.setTitle,
+                    ),
+                  ],
                   const SizedBox(height: 16),
                   // Date picker
                   _DatePicker(
@@ -355,6 +384,160 @@ class _DayChip extends StatelessWidget {
                 ? Theme.of(context).colorScheme.onPrimary
                 : Theme.of(context).colorScheme.onSurface,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChoiceOptionsEditor extends StatelessWidget {
+  final List<ChoiceOptionData> options;
+  final ActivityFormCubit cubit;
+
+  const _ChoiceOptionsEditor({
+    required this.options,
+    required this.cubit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Valgmuligheder',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        ...options.asMap().entries.map((entry) {
+          final index = entry.key;
+          final option = entry.value;
+          return _ChoiceOptionSlot(
+            index: index,
+            option: option,
+            canRemove: options.length > 2,
+            onTitleChanged: (title) =>
+                cubit.setChoiceOptionTitle(index, title),
+            onPickPictogram: () async {
+              final repo = context.read<PictogramRepository>();
+              final picked = await showDialog<Pictogram>(
+                context: context,
+                builder: (_) => RepositoryProvider.value(
+                  value: repo,
+                  child: const PictogramPickerDialog(),
+                ),
+              );
+              if (picked != null) {
+                cubit.setChoiceOptionPictogram(index, picked.id, picked.name);
+              }
+            },
+            onRemove: () => cubit.removeChoiceOption(index),
+          );
+        }),
+        if (options.length < 3)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: OutlinedButton.icon(
+              onPressed: cubit.addChoiceOption,
+              icon: const Icon(Icons.add),
+              label: const Text('Tilføj valgmulighed'),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ChoiceOptionSlot extends StatelessWidget {
+  final int index;
+  final ChoiceOptionData option;
+  final bool canRemove;
+  final ValueChanged<String> onTitleChanged;
+  final VoidCallback onPickPictogram;
+  final VoidCallback onRemove;
+
+  const _ChoiceOptionSlot({
+    required this.index,
+    required this.option,
+    required this.canRemove,
+    required this.onTitleChanged,
+    required this.onPickPictogram,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            // Pictogram thumbnail / pick button
+            GestureDetector(
+              onTap: onPickPictogram,
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: context.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(8),
+                  border: option.pictogramId == null
+                      ? Border.all(
+                          color: context.colorScheme.outline,
+                          width: 1,
+                          style: BorderStyle.solid,
+                        )
+                      : null,
+                ),
+                child: option.pictogramId != null
+                    ? Icon(
+                        Icons.check,
+                        color: context.colorScheme.primary,
+                      )
+                    : Icon(
+                        Icons.add_photo_alternate,
+                        color: context.colorScheme.outline,
+                      ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Mulighed ${index + 1}',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: context.colorScheme.outline,
+                        ),
+                  ),
+                  if (option.pictogramName != null)
+                    Text(
+                      option.pictogramName!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.colorScheme.primary,
+                          ),
+                    )
+                  else
+                    TextButton(
+                      onPressed: onPickPictogram,
+                      style: TextButton.styleFrom(
+                        padding: EdgeInsets.zero,
+                        minimumSize: Size.zero,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      child: const Text('Vælg piktogram'),
+                    ),
+                ],
+              ),
+            ),
+            if (canRemove)
+              IconButton(
+                icon: const Icon(Icons.close, size: 20),
+                onPressed: onRemove,
+              ),
+          ],
         ),
       ),
     );

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -6,6 +6,7 @@ import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/weekplan_cubit.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/activity_list_item.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/choice_selector_dialog.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/week_overview.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/week_selector.dart';
 import 'package:weekplanner/shared/models/activity.dart';
@@ -660,6 +661,10 @@ class _ActivityList extends StatelessWidget {
           imageUrl: media?.imageUrl,
           soundUrl: media?.soundUrl,
           onLongPress: () => onLongPress(activity.activityId),
+          onChoiceTap: activity.options.isNotEmpty &&
+                  activity.selectedOptionIndex == null
+              ? () => _showChoiceSelector(context, activity, cubit)
+              : null,
           onEdit: () async {
             final dateStr =
                 activity.date.toIso8601String().split('T').first;
@@ -733,6 +738,26 @@ class _ActivityList extends StatelessWidget {
         cubit.confirmDelete(activity.activityId, removed);
       }
     });
+  }
+
+  Future<void> _showChoiceSelector(
+    BuildContext context,
+    Activity activity,
+    WeekplanCubit cubit,
+  ) async {
+    final current = cubit.state;
+    if (current is! WeekplanLoaded) return;
+
+    final selectedIndex = await showDialog<int>(
+      context: context,
+      builder: (context) => ChoiceSelectorDialog(
+        activity: activity,
+        pictogramMedia: current.pictogramMedia,
+      ),
+    );
+    if (selectedIndex == null || !context.mounted) return;
+
+    cubit.selectOption(activity.activityId, selectedIndex);
   }
 }
 

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -166,6 +166,45 @@ class WeekplanCubit extends Cubit<WeekplanState> {
     }
   }
 
+  /// Select an option on a choice activity.
+  ///
+  /// Optimistically updates the activity, rolls back on server failure.
+  Future<void> selectOption(int activityId, int optionIndex) async {
+    final current = state;
+    if (current is! WeekplanLoaded) return;
+
+    final index =
+        current.activities.indexWhere((a) => a.activityId == activityId);
+    if (index == -1) return;
+
+    final activity = current.activities[index];
+    if (optionIndex < 0 || optionIndex >= activity.options.length) return;
+
+    final option = activity.options[optionIndex];
+    final updated = current.activities.map((a) {
+      if (a.activityId == activityId) {
+        return a.copyWith(
+          selectedOptionIndex: optionIndex,
+          title: option.title ?? a.title,
+          pictogramId: option.pictogramId ?? a.pictogramId,
+        );
+      }
+      return a;
+    }).toList();
+
+    emit(current.copyWith(activities: updated));
+
+    final result =
+        await _activityRepository.selectOption(activityId, optionIndex);
+    switch (result) {
+      case Left(:final value):
+        _log.warning('Select option rollback: ${value.message}');
+        emit(current.copyWith(activities: current.activities));
+      case Right():
+        break;
+    }
+  }
+
   /// Optimistically reorder activities after a drag-and-drop.
   Future<void> reorderActivities(int oldIndex, int newIndex) async {
     final current = state;

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -13,6 +13,7 @@ class ActivityListItem extends StatefulWidget {
   final VoidCallback onDelete;
   final VoidCallback onToggleStatus;
   final VoidCallback? onLongPress;
+  final VoidCallback? onChoiceTap;
   final String? imageUrl;
   final String? soundUrl;
 
@@ -23,6 +24,7 @@ class ActivityListItem extends StatefulWidget {
     required this.onDelete,
     required this.onToggleStatus,
     this.onLongPress,
+    this.onChoiceTap,
     this.imageUrl,
     this.soundUrl,
   });
@@ -70,6 +72,8 @@ class _ActivityListItemState extends State<ActivityListItem> {
     final activity = widget.activity;
     final soundUrl = widget.soundUrl;
     final hasSound = soundUrl != null && soundUrl.isNotEmpty;
+    final isUnresolvedChoice =
+        activity.options.isNotEmpty && activity.selectedOptionIndex == null;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -96,19 +100,46 @@ class _ActivityListItemState extends State<ActivityListItem> {
         child: Card(
           color: activity.isCompleted
               ? context.girafColors.completedBackground
-              : context.girafColors.pendingBackground,
+              : isUnresolvedChoice
+                  ? context.colorScheme.tertiaryContainer
+                  : context.girafColors.pendingBackground,
           child: InkWell(
-            onTap: hasSound ? _togglePlayback : null,
+            onTap: isUnresolvedChoice
+                ? widget.onChoiceTap
+                : hasSound
+                    ? _togglePlayback
+                    : null,
             onLongPress: widget.onLongPress,
             borderRadius: BorderRadius.circular(12),
             child: Padding(
               padding: const EdgeInsets.all(12),
               child: Row(
                 children: [
-                  // Pictogram — hero element
-                  _ActivityPictogram(
-                    imageUrl: widget.imageUrl,
-                    hasPictogram: activity.pictogramId != null,
+                  // Pictogram — hero element, with choice badge
+                  Stack(
+                    children: [
+                      _ActivityPictogram(
+                        imageUrl: widget.imageUrl,
+                        hasPictogram: activity.pictogramId != null,
+                      ),
+                      if (isUnresolvedChoice)
+                        Positioned(
+                          right: 0,
+                          bottom: 0,
+                          child: Container(
+                            padding: const EdgeInsets.all(2),
+                            decoration: BoxDecoration(
+                              color: context.colorScheme.tertiary,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(
+                              Icons.touch_app,
+                              size: 16,
+                              color: context.colorScheme.onTertiary,
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
                   const SizedBox(width: 16),
                   // Title and time
@@ -118,15 +149,28 @@ class _ActivityListItemState extends State<ActivityListItem> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          activity.title ?? 'Unavngivet aktivitet',
+                          isUnresolvedChoice
+                              ? (activity.title ?? 'Tryk for at vælge')
+                              : (activity.title ?? 'Unavngivet aktivitet'),
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                color: activity.title != null
-                                    ? null
-                                    : context.colorScheme.outline,
+                                color: isUnresolvedChoice
+                                    ? context.colorScheme.tertiary
+                                    : activity.title != null
+                                        ? null
+                                        : context.colorScheme.outline,
                               ),
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
+                        if (isUnresolvedChoice) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            '${activity.options.length} valgmuligheder',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: context.colorScheme.outline,
+                                ),
+                          ),
+                        ],
                         if (activity.startTime case final start?)
                           if (activity.endTime case final end?) ...[
                             const SizedBox(height: 4),

--- a/frontend/lib/features/weekplan/presentation/widgets/choice_selector_dialog.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/choice_selector_dialog.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
+import 'package:weekplanner/shared/models/activity.dart';
+
+/// Full-screen dialog for selecting an option on a choice activity.
+///
+/// Returns the selected option index, or null if dismissed.
+class ChoiceSelectorDialog extends StatelessWidget {
+  final Activity activity;
+  final Map<int, PictogramMedia> pictogramMedia;
+
+  const ChoiceSelectorDialog({
+    super.key,
+    required this.activity,
+    required this.pictogramMedia,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Hvad vil du lave?',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 24),
+            ...activity.options.asMap().entries.map((entry) {
+              final index = entry.key;
+              final option = entry.value;
+              final media = option.pictogramId != null
+                  ? pictogramMedia[option.pictogramId!]
+                  : null;
+              return _OptionCard(
+                option: option,
+                imageUrl: media?.imageUrl,
+                onTap: () => Navigator.of(context).pop(index),
+              );
+            }),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Annuller'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OptionCard extends StatelessWidget {
+  final ActivityOption option;
+  final String? imageUrl;
+  final VoidCallback onTap;
+
+  const _OptionCard({
+    required this.option,
+    this.imageUrl,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: context.colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  clipBehavior: Clip.antiAlias,
+                  child: imageUrl != null
+                      ? Image.network(
+                          imageUrl!,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, _, _) => Icon(
+                            Icons.image,
+                            size: 32,
+                            color: context.colorScheme.onPrimaryContainer,
+                          ),
+                        )
+                      : Icon(
+                          Icons.image,
+                          size: 32,
+                          color: context.colorScheme.onPrimaryContainer,
+                        ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Text(
+                    option.title ?? 'Unavngivet',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: context.colorScheme.outline,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/shared/models/pictogram.dart';
+
+/// Simplified pictogram search dialog for picking a pictogram.
+///
+/// Returns the selected [Pictogram], or null if dismissed.
+class PictogramPickerDialog extends StatefulWidget {
+  const PictogramPickerDialog({super.key});
+
+  @override
+  State<PictogramPickerDialog> createState() => _PictogramPickerDialogState();
+}
+
+class _PictogramPickerDialogState extends State<PictogramPickerDialog> {
+  final _searchController = TextEditingController();
+  List<Pictogram> _results = [];
+  bool _isSearching = false;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _search(String query) async {
+    if (query.isEmpty) return;
+    setState(() => _isSearching = true);
+
+    final repo = context.read<PictogramRepository>();
+    final result = await repo.searchPictograms(query);
+
+    if (!mounted) return;
+    setState(() {
+      _isSearching = false;
+      result.fold(
+        (_) => _results = [],
+        (pictograms) => _results = pictograms,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Vælg piktogram',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _searchController,
+                decoration: const InputDecoration(
+                  hintText: 'Søg efter piktogram...',
+                  prefixIcon: Icon(Icons.search),
+                ),
+                onSubmitted: _search,
+                textInputAction: TextInputAction.search,
+              ),
+              const SizedBox(height: 12),
+              Flexible(
+                child: _isSearching
+                    ? const Center(child: CircularProgressIndicator())
+                    : _results.isEmpty
+                        ? Center(
+                            child: Text(
+                              'Søg for at finde piktogrammer',
+                              style: TextStyle(
+                                color: context.colorScheme.outline,
+                              ),
+                            ),
+                          )
+                        : GridView.builder(
+                            shrinkWrap: true,
+                            gridDelegate:
+                                const SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: 3,
+                              mainAxisSpacing: 8,
+                              crossAxisSpacing: 8,
+                            ),
+                            itemCount: _results.length,
+                            itemBuilder: (context, index) {
+                              final pictogram = _results[index];
+                              return _PictogramGridItem(
+                                pictogram: pictogram,
+                                onTap: () =>
+                                    Navigator.of(context).pop(pictogram),
+                              );
+                            },
+                          ),
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Annuller'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PictogramGridItem extends StatelessWidget {
+  final Pictogram pictogram;
+  final VoidCallback onTap;
+
+  const _PictogramGridItem({
+    required this.pictogram,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: context.colorScheme.primaryContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: pictogram.imageUrl != null
+                ? Image.network(
+                    pictogram.imageUrl!,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, _, _) => Icon(
+                      Icons.image,
+                      color: context.colorScheme.onPrimaryContainer,
+                    ),
+                  )
+                : Icon(
+                    Icons.image,
+                    color: context.colorScheme.onPrimaryContainer,
+                  ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            pictogram.name,
+            style: Theme.of(context).textTheme.labelSmall,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/shared/models/activity.dart
+++ b/frontend/lib/shared/models/activity.dart
@@ -19,10 +19,25 @@ abstract class Activity with _$Activity {
     @Default(0) int sortOrder,
     @Default(false) bool isCompleted,
     int? pictogramId,
+    int? selectedOptionIndex,
+    @Default([]) List<ActivityOption> options,
   }) = _Activity;
 
   factory Activity.fromJson(Map<String, dynamic> json) =>
       _$ActivityFromJson(json);
+}
+
+@freezed
+abstract class ActivityOption with _$ActivityOption {
+  const factory ActivityOption({
+    required int id,
+    String? title,
+    int? pictogramId,
+    @Default(0) int sortOrder,
+  }) = _ActivityOption;
+
+  factory ActivityOption.fromJson(Map<String, dynamic> json) =>
+      _$ActivityOptionFromJson(json);
 }
 
 final _log = Logger('Activity');

--- a/frontend/lib/shared/models/activity.freezed.dart
+++ b/frontend/lib/shared/models/activity.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Activity {
 
- int get activityId;@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime get date;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get startTime;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get endTime; String? get title; int get sortOrder; bool get isCompleted; int? get pictogramId;
+ int get activityId;@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime get date;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get startTime;@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? get endTime; String? get title; int get sortOrder; bool get isCompleted; int? get pictogramId; int? get selectedOptionIndex; List<ActivityOption> get options;
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ActivityCopyWith<Activity> get copyWith => _$ActivityCopyWithImpl<Activity>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId)&&(identical(other.selectedOptionIndex, selectedOptionIndex) || other.selectedOptionIndex == selectedOptionIndex)&&const DeepCollectionEquality().equals(other.options, options));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId);
+int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId,selectedOptionIndex,const DeepCollectionEquality().hash(options));
 
 @override
 String toString() {
-  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId)';
+  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId, selectedOptionIndex: $selectedOptionIndex, options: $options)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ActivityCopyWith<$Res>  {
   factory $ActivityCopyWith(Activity value, $Res Function(Activity) _then) = _$ActivityCopyWithImpl;
 @useResult
 $Res call({
- int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId, int? selectedOptionIndex, List<ActivityOption> options
 });
 
 
@@ -65,7 +65,7 @@ class _$ActivityCopyWithImpl<$Res>
 
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,Object? selectedOptionIndex = freezed,Object? options = null,}) {
   return _then(_self.copyWith(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -75,7 +75,9 @@ as TimeValue?,title: freezed == title ? _self.title : title // ignore: cast_null
 as String?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
 as int,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,selectedOptionIndex: freezed == selectedOptionIndex ? _self.selectedOptionIndex : selectedOptionIndex // ignore: cast_nullable_to_non_nullable
+as int?,options: null == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as List<ActivityOption>,
   ));
 }
 
@@ -160,10 +162,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId,  int? selectedOptionIndex,  List<ActivityOption> options)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId,_that.selectedOptionIndex,_that.options);case _:
   return orElse();
 
 }
@@ -181,10 +183,10 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId,  int? selectedOptionIndex,  List<ActivityOption> options)  $default,) {final _that = this;
 switch (_that) {
 case _Activity():
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId,_that.selectedOptionIndex,_that.options);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -201,10 +203,10 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson)  DateTime date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson)  TimeValue? endTime,  String? title,  int sortOrder,  bool isCompleted,  int? pictogramId,  int? selectedOptionIndex,  List<ActivityOption> options)?  $default,) {final _that = this;
 switch (_that) {
 case _Activity() when $default != null:
-return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId);case _:
+return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.title,_that.sortOrder,_that.isCompleted,_that.pictogramId,_that.selectedOptionIndex,_that.options);case _:
   return null;
 
 }
@@ -216,7 +218,7 @@ return $default(_that.activityId,_that.date,_that.startTime,_that.endTime,_that.
 @JsonSerializable()
 
 class _Activity implements Activity {
-  const _Activity({required this.activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required this.date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.endTime, this.title, this.sortOrder = 0, this.isCompleted = false, this.pictogramId});
+  const _Activity({required this.activityId, @JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) required this.date, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.startTime, @JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) this.endTime, this.title, this.sortOrder = 0, this.isCompleted = false, this.pictogramId, this.selectedOptionIndex, final  List<ActivityOption> options = const []}): _options = options;
   factory _Activity.fromJson(Map<String, dynamic> json) => _$ActivityFromJson(json);
 
 @override final  int activityId;
@@ -227,6 +229,14 @@ class _Activity implements Activity {
 @override@JsonKey() final  int sortOrder;
 @override@JsonKey() final  bool isCompleted;
 @override final  int? pictogramId;
+@override final  int? selectedOptionIndex;
+ final  List<ActivityOption> _options;
+@override@JsonKey() List<ActivityOption> get options {
+  if (_options is EqualUnmodifiableListView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_options);
+}
+
 
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
@@ -241,16 +251,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Activity&&(identical(other.activityId, activityId) || other.activityId == activityId)&&(identical(other.date, date) || other.date == date)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.title, title) || other.title == title)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId)&&(identical(other.selectedOptionIndex, selectedOptionIndex) || other.selectedOptionIndex == selectedOptionIndex)&&const DeepCollectionEquality().equals(other._options, _options));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId);
+int get hashCode => Object.hash(runtimeType,activityId,date,startTime,endTime,title,sortOrder,isCompleted,pictogramId,selectedOptionIndex,const DeepCollectionEquality().hash(_options));
 
 @override
 String toString() {
-  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId)';
+  return 'Activity(activityId: $activityId, date: $date, startTime: $startTime, endTime: $endTime, title: $title, sortOrder: $sortOrder, isCompleted: $isCompleted, pictogramId: $pictogramId, selectedOptionIndex: $selectedOptionIndex, options: $options)';
 }
 
 
@@ -261,7 +271,7 @@ abstract mixin class _$ActivityCopyWith<$Res> implements $ActivityCopyWith<$Res>
   factory _$ActivityCopyWith(_Activity value, $Res Function(_Activity) _then) = __$ActivityCopyWithImpl;
 @override @useResult
 $Res call({
- int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId
+ int activityId,@JsonKey(fromJson: _dateFromJson, toJson: _dateToJson) DateTime date,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? startTime,@JsonKey(fromJson: _nullableTimeFromJson, toJson: _nullableTimeToJson) TimeValue? endTime, String? title, int sortOrder, bool isCompleted, int? pictogramId, int? selectedOptionIndex, List<ActivityOption> options
 });
 
 
@@ -278,7 +288,7 @@ class __$ActivityCopyWithImpl<$Res>
 
 /// Create a copy of Activity
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? activityId = null,Object? date = null,Object? startTime = freezed,Object? endTime = freezed,Object? title = freezed,Object? sortOrder = null,Object? isCompleted = null,Object? pictogramId = freezed,Object? selectedOptionIndex = freezed,Object? options = null,}) {
   return _then(_Activity(
 activityId: null == activityId ? _self.activityId : activityId // ignore: cast_nullable_to_non_nullable
 as int,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -288,7 +298,281 @@ as TimeValue?,title: freezed == title ? _self.title : title // ignore: cast_null
 as String?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
 as int,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,selectedOptionIndex: freezed == selectedOptionIndex ? _self.selectedOptionIndex : selectedOptionIndex // ignore: cast_nullable_to_non_nullable
+as int?,options: null == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as List<ActivityOption>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ActivityOption {
+
+ int get id; String? get title; int? get pictogramId; int get sortOrder;
+/// Create a copy of ActivityOption
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ActivityOptionCopyWith<ActivityOption> get copyWith => _$ActivityOptionCopyWithImpl<ActivityOption>(this as ActivityOption, _$identity);
+
+  /// Serializes this ActivityOption to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActivityOption&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,pictogramId,sortOrder);
+
+@override
+String toString() {
+  return 'ActivityOption(id: $id, title: $title, pictogramId: $pictogramId, sortOrder: $sortOrder)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ActivityOptionCopyWith<$Res>  {
+  factory $ActivityOptionCopyWith(ActivityOption value, $Res Function(ActivityOption) _then) = _$ActivityOptionCopyWithImpl;
+@useResult
+$Res call({
+ int id, String? title, int? pictogramId, int sortOrder
+});
+
+
+
+
+}
+/// @nodoc
+class _$ActivityOptionCopyWithImpl<$Res>
+    implements $ActivityOptionCopyWith<$Res> {
+  _$ActivityOptionCopyWithImpl(this._self, this._then);
+
+  final ActivityOption _self;
+  final $Res Function(ActivityOption) _then;
+
+/// Create a copy of ActivityOption
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = freezed,Object? pictogramId = freezed,Object? sortOrder = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
+as int?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ActivityOption].
+extension ActivityOptionPatterns on ActivityOption {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ActivityOption value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ActivityOption() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ActivityOption value)  $default,){
+final _that = this;
+switch (_that) {
+case _ActivityOption():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ActivityOption value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ActivityOption() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String? title,  int? pictogramId,  int sortOrder)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ActivityOption() when $default != null:
+return $default(_that.id,_that.title,_that.pictogramId,_that.sortOrder);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String? title,  int? pictogramId,  int sortOrder)  $default,) {final _that = this;
+switch (_that) {
+case _ActivityOption():
+return $default(_that.id,_that.title,_that.pictogramId,_that.sortOrder);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String? title,  int? pictogramId,  int sortOrder)?  $default,) {final _that = this;
+switch (_that) {
+case _ActivityOption() when $default != null:
+return $default(_that.id,_that.title,_that.pictogramId,_that.sortOrder);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ActivityOption implements ActivityOption {
+  const _ActivityOption({required this.id, this.title, this.pictogramId, this.sortOrder = 0});
+  factory _ActivityOption.fromJson(Map<String, dynamic> json) => _$ActivityOptionFromJson(json);
+
+@override final  int id;
+@override final  String? title;
+@override final  int? pictogramId;
+@override@JsonKey() final  int sortOrder;
+
+/// Create a copy of ActivityOption
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ActivityOptionCopyWith<_ActivityOption> get copyWith => __$ActivityOptionCopyWithImpl<_ActivityOption>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ActivityOptionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActivityOption&&(identical(other.id, id) || other.id == id)&&(identical(other.title, title) || other.title == title)&&(identical(other.pictogramId, pictogramId) || other.pictogramId == pictogramId)&&(identical(other.sortOrder, sortOrder) || other.sortOrder == sortOrder));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,title,pictogramId,sortOrder);
+
+@override
+String toString() {
+  return 'ActivityOption(id: $id, title: $title, pictogramId: $pictogramId, sortOrder: $sortOrder)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ActivityOptionCopyWith<$Res> implements $ActivityOptionCopyWith<$Res> {
+  factory _$ActivityOptionCopyWith(_ActivityOption value, $Res Function(_ActivityOption) _then) = __$ActivityOptionCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String? title, int? pictogramId, int sortOrder
+});
+
+
+
+
+}
+/// @nodoc
+class __$ActivityOptionCopyWithImpl<$Res>
+    implements _$ActivityOptionCopyWith<$Res> {
+  __$ActivityOptionCopyWithImpl(this._self, this._then);
+
+  final _ActivityOption _self;
+  final $Res Function(_ActivityOption) _then;
+
+/// Create a copy of ActivityOption
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = freezed,Object? pictogramId = freezed,Object? sortOrder = null,}) {
+  return _then(_ActivityOption(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,pictogramId: freezed == pictogramId ? _self.pictogramId : pictogramId // ignore: cast_nullable_to_non_nullable
+as int?,sortOrder: null == sortOrder ? _self.sortOrder : sortOrder // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/frontend/lib/shared/models/activity.g.dart
+++ b/frontend/lib/shared/models/activity.g.dart
@@ -15,6 +15,12 @@ _Activity _$ActivityFromJson(Map<String, dynamic> json) => _Activity(
   sortOrder: (json['sortOrder'] as num?)?.toInt() ?? 0,
   isCompleted: json['isCompleted'] as bool? ?? false,
   pictogramId: (json['pictogramId'] as num?)?.toInt(),
+  selectedOptionIndex: (json['selectedOptionIndex'] as num?)?.toInt(),
+  options:
+      (json['options'] as List<dynamic>?)
+          ?.map((e) => ActivityOption.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
 );
 
 Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
@@ -26,4 +32,22 @@ Map<String, dynamic> _$ActivityToJson(_Activity instance) => <String, dynamic>{
   'sortOrder': instance.sortOrder,
   'isCompleted': instance.isCompleted,
   'pictogramId': instance.pictogramId,
+  'selectedOptionIndex': instance.selectedOptionIndex,
+  'options': instance.options,
 };
+
+_ActivityOption _$ActivityOptionFromJson(Map<String, dynamic> json) =>
+    _ActivityOption(
+      id: (json['id'] as num).toInt(),
+      title: json['title'] as String?,
+      pictogramId: (json['pictogramId'] as num?)?.toInt(),
+      sortOrder: (json['sortOrder'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$ActivityOptionToJson(_ActivityOption instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'pictogramId': instance.pictogramId,
+      'sortOrder': instance.sortOrder,
+    };

--- a/frontend/lib/shared/services/activity_api_service.dart
+++ b/frontend/lib/shared/services/activity_api_service.dart
@@ -118,6 +118,14 @@ class ActivityApiService implements TokenConsumer {
     return Activity.fromJson(response.data! as Map<String, dynamic>);
   }
 
+  // Select an option on a choice activity
+  Future<Activity> selectOption(int activityId, int optionIndex) async {
+    final response = await _dio.put(
+      '/weekplan/activity/$activityId/select-option/$optionIndex',
+    );
+    return Activity.fromJson(response.data! as Map<String, dynamic>);
+  }
+
   // Delete activity
   Future<void> deleteActivity(int activityId) async {
     await _dio.delete('/weekplan/activity/$activityId');


### PR DESCRIPTION
## Summary

Full-stack choice activity feature. An activity can have 2-3 options that children select from, promoting autonomy within structured schedules.

### Backend
- `ActivityOption` entity (title, pictogramId, sortOrder) with cascade delete
- `Activity` gains `Options` collection and `SelectedOptionIndex`
- `CreateActivityDTO` accepts optional `Options` list
- `PUT /weekplan/activity/{id}/select-option/{index}` endpoint
- EF migration: `AddChoiceActivities`

### Frontend — Display & Selection
- `Activity` and `ActivityOption` freezed models with codegen
- Unresolved choices: tertiary container background, touch badge, "Tryk for at vælge", option count
- `ChoiceSelectorDialog`: large pictogram cards for each option
- `WeekplanCubit.selectOption()` with optimistic update + rollback

### Frontend — Creation
- "Valgaktivitet" toggle in activity form (new activities only)
- 2-3 option slots, each with pictogram search picker and title
- `PictogramPickerDialog`: simplified search + grid picker for per-option pictogram selection
- Validation: all options must have a pictogram
- Options sent to backend in create payload

## Test plan

- [x] Backend: 54 tests pass, 0 warnings
- [x] Frontend: 226 tests pass, `dart analyze` zero issues
- [ ] Manual: toggle "Valgaktivitet" → add 2-3 options with pictograms → save
- [ ] Manual: verify choice activity shows in schedule with touch badge
- [ ] Manual: tap choice → dialog shows options → select one → resolves
- [ ] Manual: regular activities unchanged

Closes #63