### PR TITLE
fix: unify pictogram name and activity title

### DIFF
--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -157,14 +157,15 @@ final class PictogramSelection with EquatableMixin {
 // ── Sub-state: Pictogram creation (upload / generate) ──────
 
 /// Form state for creating a new pictogram via upload or AI generation.
+///
+/// The pictogram name comes from [ActivityFormData.title] — there is no
+/// separate name field. Caregivers see one "Titel" field that serves as
+/// both the activity title and the pictogram name.
 final class PictogramCreation with EquatableMixin {
   /// Current pictogram selection mode.
   final PictogramMode mode;
 
-  /// Name for a new pictogram being created.
-  final String name;
-
-  /// AI generation prompt for a new pictogram.
+  /// AI generation prompt (optional description for image generation).
   final String generatePrompt;
 
   /// Selected image file for upload mode.
@@ -181,7 +182,6 @@ final class PictogramCreation with EquatableMixin {
 
   const PictogramCreation({
     this.mode = PictogramMode.search,
-    this.name = '',
     this.generatePrompt = '',
     this.imageFile,
     this.soundFile,
@@ -191,7 +191,6 @@ final class PictogramCreation with EquatableMixin {
 
   PictogramCreation copyWith({
     PictogramMode? mode,
-    String? name,
     String? generatePrompt,
     FileData? imageFile,
     FileData? soundFile,
@@ -202,7 +201,6 @@ final class PictogramCreation with EquatableMixin {
   }) {
     return PictogramCreation(
       mode: mode ?? this.mode,
-      name: name ?? this.name,
       generatePrompt: generatePrompt ?? this.generatePrompt,
       imageFile: clearImageFile ? null : (imageFile ?? this.imageFile),
       soundFile: clearSoundFile ? null : (soundFile ?? this.soundFile),
@@ -214,10 +212,7 @@ final class PictogramCreation with EquatableMixin {
   @override
   List<Object?> get props => [
         mode,
-        name,
         generatePrompt,
-        // FileData is a record — Dart records have structural equality,
-        // but the Uint8List bytes field uses identity comparison.
         imageFile,
         soundFile,
         generateSound,

--- a/frontend/lib/features/weekplan/domain/activity_form_state.dart
+++ b/frontend/lib/features/weekplan/domain/activity_form_state.dart
@@ -165,9 +165,6 @@ final class PictogramCreation with EquatableMixin {
   /// Current pictogram selection mode.
   final PictogramMode mode;
 
-  /// AI generation prompt (optional description for image generation).
-  final String generatePrompt;
-
   /// Selected image file for upload mode.
   final FileData? imageFile;
 
@@ -182,7 +179,6 @@ final class PictogramCreation with EquatableMixin {
 
   const PictogramCreation({
     this.mode = PictogramMode.search,
-    this.generatePrompt = '',
     this.imageFile,
     this.soundFile,
     this.generateSound = true,
@@ -191,7 +187,6 @@ final class PictogramCreation with EquatableMixin {
 
   PictogramCreation copyWith({
     PictogramMode? mode,
-    String? generatePrompt,
     FileData? imageFile,
     FileData? soundFile,
     bool? generateSound,
@@ -201,7 +196,6 @@ final class PictogramCreation with EquatableMixin {
   }) {
     return PictogramCreation(
       mode: mode ?? this.mode,
-      generatePrompt: generatePrompt ?? this.generatePrompt,
       imageFile: clearImageFile ? null : (imageFile ?? this.imageFile),
       soundFile: clearSoundFile ? null : (soundFile ?? this.soundFile),
       generateSound: generateSound ?? this.generateSound,
@@ -212,7 +206,6 @@ final class PictogramCreation with EquatableMixin {
   @override
   List<Object?> get props => [
         mode,
-        generatePrompt,
         imageFile,
         soundFile,
         generateSound,

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -137,10 +137,6 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     _emitReady(creation: state.creation.copyWith(mode: mode));
   }
 
-  void setPictogramName(String name) {
-    _emitReady(creation: state.creation.copyWith(name: name));
-  }
-
   void setGeneratePrompt(String prompt) {
     _emitReady(creation: state.creation.copyWith(generatePrompt: prompt));
   }
@@ -201,17 +197,17 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
   // ── Pictogram creation ───────────────────────────────────
 
   /// Upload a local image as a new pictogram and select it.
-  Future<bool> uploadPictogramFromFile() async {
+  ///
+  /// Uses [ActivityFormData.title] as the pictogram name — there is no
+  /// separate name field.
+  Future<bool> _uploadPictogramFromFile() async {
     final imageFile = state.creation.imageFile;
-    if (imageFile == null || state.creation.name.isEmpty) {
-      _emitReady(error: 'Angiv navn og vælg et billede');
-      return false;
-    }
+    if (imageFile == null) return false;
 
     _emitReady(creation: state.creation.copyWith(isCreating: true));
 
     final result = await _pictogramRepository.uploadPictogram(
-      name: state.creation.name,
+      name: state.form.title,
       imageFile: imageFile,
       soundFile: state.creation.soundFile,
       organizationId: organizationId,
@@ -229,26 +225,26 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         _emitReady(
           creation: state.creation.copyWith(isCreating: false),
           selection: PictogramSelection(id: value.id, pictogram: value),
-          form: state.form.copyWith(title: value.name),
         );
         return true;
     }
   }
 
   /// Create a pictogram via AI generation and select it.
+  ///
+  /// Uses [ActivityFormData.title] as the pictogram name. The optional
+  /// [PictogramCreation.generatePrompt] provides an AI description for
+  /// image generation — if empty, the title is used as the prompt too.
   Future<bool> generatePictogram() async {
-    final prompt = state.creation.generatePrompt.isNotEmpty
-        ? state.creation.generatePrompt
-        : state.creation.name;
-    if (prompt.isEmpty) {
-      _emitReady(error: 'Angiv et navn eller en beskrivelse');
+    if (state.form.title.isEmpty) {
+      _emitReady(error: 'Angiv en titel først');
       return false;
     }
 
     _emitReady(creation: state.creation.copyWith(isCreating: true));
 
     final result = await _pictogramRepository.createPictogram(
-      name: prompt,
+      name: state.form.title,
       organizationId: organizationId,
       generateImage: true,
       generateSound: state.creation.generateSound,
@@ -265,7 +261,6 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         _emitReady(
           creation: state.creation.copyWith(isCreating: false),
           selection: PictogramSelection(id: value.id, pictogram: value),
-          form: state.form.copyWith(title: value.name),
         );
         return true;
     }
@@ -273,8 +268,20 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
 
   // ── Validation and save ──────────────────────────────────
 
+  /// Whether the form has a pending pictogram upload (image picked but not
+  /// yet sent to the server).
+  bool get _hasPendingUpload =>
+      state.creation.mode == PictogramMode.upload &&
+      state.creation.imageFile != null &&
+      state.selection.id == null;
+
   /// Validate the form and return an error message, or null if valid.
   String? validate() {
+    // Title is required when uploading or generating a pictogram, since it
+    // doubles as the pictogram name.
+    if (_hasPendingUpload && state.form.title.isEmpty) {
+      return 'Angiv en titel';
+    }
     if (state.form.isChoiceActivity) {
       for (final option in state.form.choiceOptions) {
         if (option.pictogramId == null) {
@@ -282,7 +289,7 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
         }
       }
     } else {
-      if (state.selection.id == null) {
+      if (state.selection.id == null && !_hasPendingUpload) {
         return 'Vælg et piktogram';
       }
     }
@@ -299,11 +306,21 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
   }
 
   /// Save the activity (create or update). Returns true on success.
+  ///
+  /// When the user has picked an image file (upload mode), the pictogram
+  /// is created first using the activity title as its name. This ensures
+  /// the title is known before the pictogram is sent to the server.
   Future<bool> save() async {
     final validationError = validate();
     if (validationError != null) {
       _emitReady(error: validationError);
       return false;
+    }
+
+    // Deferred upload: create the pictogram now that the title is set.
+    if (_hasPendingUpload) {
+      final uploaded = await _uploadPictogramFromFile();
+      if (!uploaded) return false;
     }
 
     final s = state;

--- a/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/activity_form_cubit.dart
@@ -137,10 +137,6 @@ class ActivityFormCubit extends Cubit<ActivityFormState> {
     _emitReady(creation: state.creation.copyWith(mode: mode));
   }
 
-  void setGeneratePrompt(String prompt) {
-    _emitReady(creation: state.creation.copyWith(generatePrompt: prompt));
-  }
-
   void setSelectedImageFile(FileData? file) {
     if (file == null) {
       _emitReady(creation: state.creation.copyWith(clearImageFile: true));

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -18,12 +18,10 @@ class PictogramSelector extends StatefulWidget {
 
 class _PictogramSelectorState extends State<PictogramSelector> {
   final _searchController = TextEditingController();
-  final _promptController = TextEditingController();
 
   @override
   void dispose() {
     _searchController.dispose();
-    _promptController.dispose();
     super.dispose();
   }
 
@@ -79,10 +77,8 @@ class _PictogramSelectorState extends State<PictogramSelector> {
                   onGenerateSoundChanged: cubit.setGenerateSound,
                 ),
               PictogramMode.generate => _GenerateTab(
-                  promptController: _promptController,
                   generateSound: state.creation.generateSound,
                   isCreatingPictogram: state.creation.isCreating,
-                  onPromptChanged: cubit.setGeneratePrompt,
                   onGenerateSoundChanged: cubit.setGenerateSound,
                   onGenerate: cubit.generatePictogram,
                 ),
@@ -91,6 +87,7 @@ class _PictogramSelectorState extends State<PictogramSelector> {
             // Selected pictogram preview
             if (state.selection.pictogram != null) ...[
               const SizedBox(height: 12),
+              // Guarded by != null check above.
               _SelectedPictogramPreview(pictogram: state.selection.pictogram!),
             ],
           ],
@@ -303,18 +300,14 @@ class _UploadTab extends StatelessWidget {
 /// AI generation tab: optional prompt and sound toggle. The pictogram
 /// name comes from the activity title field — no separate name input.
 class _GenerateTab extends StatelessWidget {
-  final TextEditingController promptController;
   final bool generateSound;
   final bool isCreatingPictogram;
-  final ValueChanged<String> onPromptChanged;
   final ValueChanged<bool> onGenerateSoundChanged;
   final Future<bool> Function() onGenerate;
 
   const _GenerateTab({
-    required this.promptController,
     required this.generateSound,
     required this.isCreatingPictogram,
-    required this.onPromptChanged,
     required this.onGenerateSoundChanged,
     required this.onGenerate,
   });
@@ -324,18 +317,6 @@ class _GenerateTab extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        TextField(
-          controller: promptController,
-          onChanged: onPromptChanged,
-          maxLines: 2,
-          decoration: const InputDecoration(
-            labelText: 'Beskrivelse til AI (valgfrit)',
-            hintText: 'Beskriv hvad billedet skal vise...',
-            helperText:
-                'Lad feltet stå tomt for at bruge titlen som beskrivelse',
-          ),
-        ),
-        const SizedBox(height: 8),
         SwitchListTile(
           title: const Text('Generer lyd'),
           subtitle: const Text('AI-genereret udtale af titlen'),

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -17,13 +18,11 @@ class PictogramSelector extends StatefulWidget {
 
 class _PictogramSelectorState extends State<PictogramSelector> {
   final _searchController = TextEditingController();
-  final _nameController = TextEditingController();
   final _promptController = TextEditingController();
 
   @override
   void dispose() {
     _searchController.dispose();
-    _nameController.dispose();
     _promptController.dispose();
     super.dispose();
   }
@@ -62,19 +61,36 @@ class _PictogramSelectorState extends State<PictogramSelector> {
             const SizedBox(height: 12),
 
             // Content per mode
-            _PictogramModeContent(
-              mode: state.creation.mode,
-              state: state,
-              cubit: cubit,
-              searchController: _searchController,
-              nameController: _nameController,
-              promptController: _promptController,
-            ),
+            switch (state.creation.mode) {
+              PictogramMode.search => _SearchTab(
+                  controller: _searchController,
+                  onSearchChanged: cubit.onSearchQueryChanged,
+                  pictograms: state.search.results,
+                  isLoading: state.search.isSearching,
+                  selectedId: state.selection.id,
+                  onSelect: cubit.selectPictogram,
+                ),
+              PictogramMode.upload => _UploadTab(
+                  selectedImageFile: state.creation.imageFile,
+                  selectedSoundFile: state.creation.soundFile,
+                  generateSound: state.creation.generateSound,
+                  onImageFilePicked: cubit.setSelectedImageFile,
+                  onSoundFilePicked: cubit.setSelectedSoundFile,
+                  onGenerateSoundChanged: cubit.setGenerateSound,
+                ),
+              PictogramMode.generate => _GenerateTab(
+                  promptController: _promptController,
+                  generateSound: state.creation.generateSound,
+                  isCreatingPictogram: state.creation.isCreating,
+                  onPromptChanged: cubit.setGeneratePrompt,
+                  onGenerateSoundChanged: cubit.setGenerateSound,
+                  onGenerate: cubit.generatePictogram,
+                ),
+            },
 
             // Selected pictogram preview
             if (state.selection.pictogram != null) ...[
               const SizedBox(height: 12),
-              // Guarded by != null check above.
               _SelectedPictogramPreview(pictogram: state.selection.pictogram!),
             ],
           ],
@@ -84,64 +100,7 @@ class _PictogramSelectorState extends State<PictogramSelector> {
   }
 }
 
-// ── Mode content router ───────────────────────────────────────
-
-/// Renders the appropriate tab content based on the selected [PictogramMode].
-class _PictogramModeContent extends StatelessWidget {
-  const _PictogramModeContent({
-    required this.mode,
-    required this.state,
-    required this.cubit,
-    required this.searchController,
-    required this.nameController,
-    required this.promptController,
-  });
-
-  final PictogramMode mode;
-  final ActivityFormState state;
-  final ActivityFormCubit cubit;
-  final TextEditingController searchController;
-  final TextEditingController nameController;
-  final TextEditingController promptController;
-
-  @override
-  Widget build(BuildContext context) {
-    return switch (mode) {
-      PictogramMode.search => _SearchTab(
-          controller: searchController,
-          onSearchChanged: cubit.onSearchQueryChanged,
-          pictograms: state.search.results,
-          isLoading: state.search.isSearching,
-          selectedId: state.selection.id,
-          onSelect: cubit.selectPictogram,
-        ),
-      PictogramMode.upload => _UploadTab(
-          nameController: nameController,
-          selectedImageFile: state.creation.imageFile,
-          selectedSoundFile: state.creation.soundFile,
-          generateSound: state.creation.generateSound,
-          isCreatingPictogram: state.creation.isCreating,
-          onNameChanged: cubit.setPictogramName,
-          onImageFilePicked: cubit.setSelectedImageFile,
-          onSoundFilePicked: cubit.setSelectedSoundFile,
-          onGenerateSoundChanged: cubit.setGenerateSound,
-          onUpload: cubit.uploadPictogramFromFile,
-        ),
-      PictogramMode.generate => _GenerateTab(
-          nameController: nameController,
-          promptController: promptController,
-          generateSound: state.creation.generateSound,
-          isCreatingPictogram: state.creation.isCreating,
-          onNameChanged: cubit.setPictogramName,
-          onPromptChanged: cubit.setGeneratePrompt,
-          onGenerateSoundChanged: cubit.setGenerateSound,
-          onGenerate: cubit.generatePictogram,
-        ),
-    };
-  }
-}
-
-// ── Search tab (existing behavior) ──────────────────────────
+// ── Search tab ────────────────────────────────────────────────
 
 class _SearchTab extends StatelessWidget {
   final TextEditingController controller;
@@ -245,31 +204,26 @@ class _SearchTab extends StatelessWidget {
   }
 }
 
-// ── Upload tab ──────────────────────────────────────────────
+// ── Upload tab ────────────────────────────────────────────────
 
+/// Simplified upload tab: pick image, optionally pick sound or toggle
+/// auto-generation. No separate name field — the activity title (set in
+/// the form below) is used as the pictogram name on submit.
 class _UploadTab extends StatelessWidget {
-  final TextEditingController nameController;
   final FileData? selectedImageFile;
   final FileData? selectedSoundFile;
   final bool generateSound;
-  final bool isCreatingPictogram;
-  final ValueChanged<String> onNameChanged;
   final ValueChanged<FileData?> onImageFilePicked;
   final ValueChanged<FileData?> onSoundFilePicked;
   final ValueChanged<bool> onGenerateSoundChanged;
-  final Future<bool> Function() onUpload;
 
   const _UploadTab({
-    required this.nameController,
     required this.selectedImageFile,
     required this.selectedSoundFile,
     required this.generateSound,
-    required this.isCreatingPictogram,
-    required this.onNameChanged,
     required this.onImageFilePicked,
     required this.onSoundFilePicked,
     required this.onGenerateSoundChanged,
-    required this.onUpload,
   });
 
   @override
@@ -277,18 +231,9 @@ class _UploadTab extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        TextField(
-          controller: nameController,
-          onChanged: onNameChanged,
-          decoration: const InputDecoration(
-            labelText: 'Navn',
-            hintText: 'Giv piktogrammet et navn...',
-          ),
-        ),
-        const SizedBox(height: 12),
         OutlinedButton.icon(
           onPressed: () async {
-            final file = await _pickFile(['jpg', 'jpeg', 'png', 'webp']);
+            final file = await _pickImageFile();
             if (file != null) onImageFilePicked(file);
           },
           icon: const Icon(Icons.image),
@@ -301,7 +246,7 @@ class _UploadTab extends StatelessWidget {
         const SizedBox(height: 8),
         OutlinedButton.icon(
           onPressed: () async {
-            final file = await _pickFile(['mp3']);
+            final file = await _pickSoundFile();
             if (file != null) onSoundFilePicked(file);
           },
           icon: const Icon(Icons.audiotrack),
@@ -314,62 +259,61 @@ class _UploadTab extends StatelessWidget {
         const SizedBox(height: 8),
         SwitchListTile(
           title: const Text('Generer lyd automatisk'),
-          subtitle: const Text('AI-genereret udtale af navnet'),
+          subtitle: const Text('AI-genereret udtale af titlen'),
           value: generateSound,
           onChanged: onGenerateSoundChanged,
           contentPadding: EdgeInsets.zero,
-        ),
-        const SizedBox(height: 12),
-        ElevatedButton(
-          onPressed: isCreatingPictogram ? null : onUpload,
-          child: isCreatingPictogram
-              ? const SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : const Text('Upload piktogram'),
         ),
       ],
     );
   }
 
-  /// Pick a file and convert to domain-safe [FileData].
-  Future<FileData?> _pickFile(List<String> extensions) async {
+  Future<FileData?> _pickImageFile() async {
     final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: extensions,
+      type: FileType.image,
       withData: true,
     );
+    return _toFileData(result);
+  }
+
+  Future<FileData?> _pickSoundFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['mp3', 'wav', 'ogg'],
+      withData: true,
+    );
+    return _toFileData(result);
+  }
+
+  FileData? _toFileData(FilePickerResult? result) {
     final file = result?.files.single;
     if (file == null) return null;
     return (
       name: file.name,
       size: file.size,
       bytes: file.bytes,
-      path: file.path,
+      // PlatformFile.path throws on web — skip it there.
+      path: kIsWeb ? null : file.path,
     );
   }
 }
 
-// ── Generate tab ────────────────────────────────────────────
+// ── Generate tab ──────────────────────────────────────────────
 
+/// AI generation tab: optional prompt and sound toggle. The pictogram
+/// name comes from the activity title field — no separate name input.
 class _GenerateTab extends StatelessWidget {
-  final TextEditingController nameController;
   final TextEditingController promptController;
   final bool generateSound;
   final bool isCreatingPictogram;
-  final ValueChanged<String> onNameChanged;
   final ValueChanged<String> onPromptChanged;
   final ValueChanged<bool> onGenerateSoundChanged;
   final Future<bool> Function() onGenerate;
 
   const _GenerateTab({
-    required this.nameController,
     required this.promptController,
     required this.generateSound,
     required this.isCreatingPictogram,
-    required this.onNameChanged,
     required this.onPromptChanged,
     required this.onGenerateSoundChanged,
     required this.onGenerate,
@@ -381,15 +325,6 @@ class _GenerateTab extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         TextField(
-          controller: nameController,
-          onChanged: onNameChanged,
-          decoration: const InputDecoration(
-            labelText: 'Navn',
-            hintText: 'Giv piktogrammet et navn...',
-          ),
-        ),
-        const SizedBox(height: 12),
-        TextField(
           controller: promptController,
           onChanged: onPromptChanged,
           maxLines: 2,
@@ -397,13 +332,13 @@ class _GenerateTab extends StatelessWidget {
             labelText: 'Beskrivelse til AI (valgfrit)',
             hintText: 'Beskriv hvad billedet skal vise...',
             helperText:
-                'Lad feltet stå tomt for at bruge navnet som beskrivelse',
+                'Lad feltet stå tomt for at bruge titlen som beskrivelse',
           ),
         ),
         const SizedBox(height: 8),
         SwitchListTile(
           title: const Text('Generer lyd'),
-          subtitle: const Text('AI-genereret udtale af navnet'),
+          subtitle: const Text('AI-genereret udtale af titlen'),
           value: generateSound,
           onChanged: onGenerateSoundChanged,
           contentPadding: EdgeInsets.zero,
@@ -425,7 +360,7 @@ class _GenerateTab extends StatelessWidget {
   }
 }
 
-// ── Selected pictogram preview ──────────────────────────────
+// ── Selected pictogram preview ────────────────────────────────
 
 class _SelectedPictogramPreview extends StatelessWidget {
   final Pictogram pictogram;

--- a/frontend/test/features/weekplan/activity_form_cubit_test.dart
+++ b/frontend/test/features/weekplan/activity_form_cubit_test.dart
@@ -299,18 +299,26 @@ void main() {
     );
   });
 
-  group('uploadPictogramFromFile', () {
-    test('returns false and emits error when name or file is missing', () async {
+  group('deferred pictogram upload via save', () {
+    test('save validates title is required when image file is pending',
+        () async {
       final cubit = buildCubit();
-      final result = await cubit.uploadPictogramFromFile();
+      cubit.setPictogramMode(PictogramMode.upload);
+      final FileData fakeFile =
+          (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
+      cubit.setSelectedImageFile(fakeFile);
+
+      final result = await cubit.save();
       expect(result, isFalse);
-      expect(cubit.state, isA<ActivityFormReady>());
-      expect((cubit.state as ActivityFormReady).error,
-          'Angiv navn og vælg et billede');
+      expect(
+        (cubit.state as ActivityFormReady).error,
+        'Angiv en titel',
+      );
       cubit.close();
     });
 
-    test('returns true and selects pictogram on success', () async {
+    test('save uploads pictogram using title as name then creates activity',
+        () async {
       when(
         () => mockPictogramRepo.uploadPictogram(
           name: any(named: 'name'),
@@ -320,22 +328,38 @@ void main() {
           generateSound: any(named: 'generateSound'),
         ),
       ).thenAnswer((_) async => const Right(testPictogram));
+      when(
+        () => mockActivityRepo.createActivity(
+          id: any(named: 'id'),
+          isCitizen: any(named: 'isCitizen'),
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer((_) async => Right(testActivity));
 
       final cubit = buildCubit();
-      // Seed state with name and image file
-      cubit.setPictogramName('test');
-      final FileData fakeFile = (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
+      cubit.setTitle('Leg udenfor');
+      cubit.setPictogramMode(PictogramMode.upload);
+      final FileData fakeFile =
+          (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
       cubit.setSelectedImageFile(fakeFile);
 
-      final result = await cubit.uploadPictogramFromFile();
+      final result = await cubit.save();
       expect(result, isTrue);
-      expect(cubit.state, isA<ActivityFormReady>());
-      expect(cubit.state.selection.id, 1);
-      expect(cubit.state.selection.pictogram, testPictogram);
+
+      // Verify pictogram was uploaded with the title as name
+      verify(
+        () => mockPictogramRepo.uploadPictogram(
+          name: 'Leg udenfor',
+          imageFile: fakeFile,
+          soundFile: null,
+          organizationId: null,
+          generateSound: true,
+        ),
+      ).called(1);
       cubit.close();
     });
 
-    test('returns false and emits error message on failure', () async {
+    test('save emits error when upload fails', () async {
       when(
         () => mockPictogramRepo.uploadPictogram(
           name: any(named: 'name'),
@@ -347,11 +371,13 @@ void main() {
       ).thenAnswer((_) async => const Left(CreatePictogramFailure()));
 
       final cubit = buildCubit();
-      cubit.setPictogramName('test');
-      final FileData fakeFile = (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
+      cubit.setTitle('Leg udenfor');
+      cubit.setPictogramMode(PictogramMode.upload);
+      final FileData fakeFile =
+          (name: 'image.png', size: 0, bytes: Uint8List(0), path: null);
       cubit.setSelectedImageFile(fakeFile);
 
-      final result = await cubit.uploadPictogramFromFile();
+      final result = await cubit.save();
       expect(result, isFalse);
       expect((cubit.state as ActivityFormReady).error,
           'Kunne ikke oprette piktogram');
@@ -360,12 +386,12 @@ void main() {
   });
 
   group('generatePictogram', () {
-    test('returns false and emits error when prompt is empty', () async {
+    test('returns false and emits error when title is empty', () async {
       final cubit = buildCubit();
       final result = await cubit.generatePictogram();
       expect(result, isFalse);
       expect((cubit.state as ActivityFormReady).error,
-          'Angiv et navn eller en beskrivelse');
+          'Angiv en titel først');
       cubit.close();
     });
 
@@ -380,7 +406,7 @@ void main() {
       ).thenAnswer((_) async => const Right(testPictogram));
 
       final cubit = buildCubit();
-      cubit.setPictogramName('cat');
+      cubit.setTitle('cat');
 
       final result = await cubit.generatePictogram();
       expect(result, isTrue);
@@ -400,7 +426,7 @@ void main() {
       ).thenAnswer((_) async => const Left(CreatePictogramFailure()));
 
       final cubit = buildCubit();
-      cubit.setGeneratePrompt('a cat playing');
+      cubit.setTitle('a cat playing');
 
       final result = await cubit.generatePictogram();
       expect(result, isFalse);

--- a/frontend/test/features/weekplan/pictogram_selector_test.dart
+++ b/frontend/test/features/weekplan/pictogram_selector_test.dart
@@ -103,7 +103,7 @@ void main() {
       expect(find.text('Generer lyd automatisk'), findsOneWidget);
     });
 
-    testWidgets('generate mode shows prompt field but no name field',
+    testWidgets('generate mode shows sound toggle and generate button',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: defaultForm,
@@ -113,7 +113,8 @@ void main() {
       await tester.pumpWidget(buildSubject());
 
       expect(find.text('Navn'), findsNothing);
-      expect(find.text('Beskrivelse til AI (valgfrit)'), findsOneWidget);
+      expect(find.text('Generer lyd'), findsOneWidget);
+      expect(find.text('Generer piktogram'), findsOneWidget);
     });
 
     testWidgets('shows selected pictogram preview with name and check icon',

--- a/frontend/test/features/weekplan/pictogram_selector_test.dart
+++ b/frontend/test/features/weekplan/pictogram_selector_test.dart
@@ -90,7 +90,7 @@ void main() {
       expect(find.text('test'), findsOneWidget);
     });
 
-    testWidgets('upload mode shows name field and image button', (tester) async {
+    testWidgets('upload mode shows image and sound buttons', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: defaultForm,
         creation: const PictogramCreation(mode: PictogramMode.upload),
@@ -98,11 +98,12 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      expect(find.text('Navn'), findsOneWidget);
       expect(find.text('Vælg billede'), findsOneWidget);
+      expect(find.text('Vælg lydfil (valgfrit)'), findsOneWidget);
+      expect(find.text('Generer lyd automatisk'), findsOneWidget);
     });
 
-    testWidgets('generate mode shows name field and prompt field',
+    testWidgets('generate mode shows prompt field but no name field',
         (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: defaultForm,
@@ -111,6 +112,7 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
+      expect(find.text('Navn'), findsNothing);
       expect(find.text('Beskrivelse til AI (valgfrit)'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary

- Removes the separate "Navn" field from Upload and Generate tabs in the activity form
- One "Titel" field now serves as both the activity title and the pictogram name
- Upload is deferred to form submit so the title is known before the pictogram is created (fixes TTS using filenames like "pxl21312451.png")
- Fixes `PlatformFile.path` crash on Flutter web with `kIsWeb` guard

## Test plan

- [x] `dart analyze` — zero warnings
- [x] `flutter test` — 226 tests pass
- [ ] Manual: Search flow — select pictogram, title auto-fills, submit works
- [ ] Manual: Upload flow — type title, pick image, submit creates pictogram with title as name
- [ ] Manual: Upload without title — shows "Angiv en titel" error
- [ ] Manual: Generate flow — type title, click generate, pictogram created with title as name