### PR TITLE
chore: modernize theme to use M3 tonal palette

### DIFF
--- a/frontend/lib/config/theme.dart
+++ b/frontend/lib/config/theme.dart
@@ -1,21 +1,24 @@
 import 'package:flutter/material.dart';
 
-/// Internal color palette used only by [girafTheme].
+/// Internal color palette used only by [girafTheme] and [GirafThemeExtension].
 ///
 /// In widgets, use [Theme.of] via the [GirafThemeX] extension instead.
 class GirafColors {
   static const Color orange = Color(0xFFFF8C00);
   static const Color lighterOrange = Color(0xFFFFD494);
-  static const Color black = Color(0xFF1A1A1A);
   static const Color white = Color(0xFFFFFFFF);
-  static const Color gray = Color(0xFF808080);
-  static const Color lightGray = Color(0xFFF0F0F0);
   static const Color blue = Color(0xFF006EB8);
   static const Color lightBlue = Color(0xFFE0F4FF);
   static const Color green = Color(0xFF4CAF50);
   static const Color lightGreen = Color(0xFFE5F5E5);
-  static const Color red = Color(0xFFFF0000);
   static const Color lightRed = Color(0xFFFFE5E5);
+}
+
+/// Standard shape radii for the GIRAF design system.
+class GirafShape {
+  static const double radiusSmall = 8;
+  static const double radiusMedium = 12;
+  static const double radiusLarge = 16;
 }
 
 /// Custom theme extension for GIRAF-specific semantic colors.
@@ -98,13 +101,6 @@ extension GirafThemeX on BuildContext {
 final ThemeData girafTheme = ThemeData(
   colorScheme: ColorScheme.fromSeed(
     seedColor: GirafColors.orange,
-    primary: GirafColors.orange,
-    onPrimary: GirafColors.white,
-    surface: GirafColors.white,
-    error: GirafColors.red,
-    onSurface: GirafColors.black,
-    outline: GirafColors.gray,
-    surfaceContainerLow: GirafColors.lightGray,
   ),
   extensions: const [
     GirafThemeExtension(
@@ -120,19 +116,27 @@ final ThemeData girafTheme = ThemeData(
     backgroundColor: GirafColors.orange,
     foregroundColor: GirafColors.white,
     elevation: 0,
+    scrolledUnderElevation: 0,
   ),
-  elevatedButtonTheme: ElevatedButtonThemeData(
-    style: ElevatedButton.styleFrom(
+  filledButtonTheme: FilledButtonThemeData(
+    style: FilledButton.styleFrom(
       backgroundColor: GirafColors.orange,
       foregroundColor: GirafColors.white,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
     ),
   ),
+  cardTheme: CardThemeData(
+    elevation: 0,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(GirafShape.radiusLarge),
+    ),
+  ),
   inputDecorationTheme: InputDecorationTheme(
-    border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
+    ),
     focusedBorder: OutlineInputBorder(
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
       borderSide: const BorderSide(color: GirafColors.orange, width: 2),
     ),
     contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),

--- a/frontend/lib/features/auth/presentation/views/login_view.dart
+++ b/frontend/lib/features/auth/presentation/views/login_view.dart
@@ -85,7 +85,7 @@ class LoginView extends StatelessWidget {
                           padding: const EdgeInsets.all(12),
                           decoration: BoxDecoration(
                             color: context.girafColors.errorBackground,
-                            borderRadius: BorderRadius.circular(8),
+                            borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
                           ),
                           child: Text(
                             errorMessage,
@@ -96,7 +96,7 @@ class LoginView extends StatelessWidget {
                           ),
                         ),
                       const SizedBox(height: 16),
-                      ElevatedButton(
+                      FilledButton(
                         onPressed: isLoading
                             ? null
                             : () =>

--- a/frontend/lib/features/organisation_picker/presentation/views/organisation_picker_view.dart
+++ b/frontend/lib/features/organisation_picker/presentation/views/organisation_picker_view.dart
@@ -61,7 +61,7 @@ class _ErrorWithRetry extends StatelessWidget {
             style: TextStyle(color: context.colorScheme.error),
           ),
           const SizedBox(height: 16),
-          ElevatedButton(
+          FilledButton(
             onPressed: () =>
                 context.read<OrganisationPickerCubit>().loadOrganisations(),
             child: const Text('Prøv igen'),

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -175,7 +175,7 @@ class ActivityFormView extends StatelessWidget {
                         textAlign: TextAlign.center,
                       ),
                     ),
-                  ElevatedButton(
+                  FilledButton(
                     onPressed: isSaving
                         ? null
                         : () => cubit.save(),
@@ -481,7 +481,7 @@ class _ChoiceOptionSlot extends StatelessWidget {
                 height: 56,
                 decoration: BoxDecoration(
                   color: context.colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(8),
+                  borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
                   border: option.pictogramId == null
                       ? Border.all(
                           color: context.colorScheme.outline,

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -553,7 +553,7 @@ class _ErrorWithRetry extends StatelessWidget {
             style: TextStyle(color: context.colorScheme.error),
           ),
           const SizedBox(height: 16),
-          ElevatedButton(
+          FilledButton(
             onPressed: () => context.read<WeekplanCubit>().loadActivities(),
             child: const Text('Prøv igen'),
           ),
@@ -643,7 +643,7 @@ class _ActivityList extends StatelessWidget {
           animation: animation,
           builder: (context, child) => Material(
             elevation: 4,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
             child: child,
           ),
           child: child,
@@ -786,7 +786,7 @@ class _SelectableActivityItem extends StatelessWidget {
             : null,
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
           child: Padding(
             padding: const EdgeInsets.all(12),
             child: Row(
@@ -802,7 +802,7 @@ class _SelectableActivityItem extends StatelessWidget {
                   height: 48,
                   decoration: BoxDecoration(
                     color: context.colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
                   ),
                   clipBehavior: Clip.antiAlias,
                   child: imageUrl != null

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_list_item.dart
@@ -110,7 +110,7 @@ class _ActivityListItemState extends State<ActivityListItem> {
                     ? _togglePlayback
                     : null,
             onLongPress: widget.onLongPress,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
             child: Padding(
               padding: const EdgeInsets.all(12),
               child: Row(
@@ -224,7 +224,7 @@ class _ActivityPictogram extends StatelessWidget {
       height: 96,
       decoration: BoxDecoration(
         color: context.colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
       ),
       clipBehavior: Clip.antiAlias,
       child: switch (imageUrl) {

--- a/frontend/lib/features/weekplan/presentation/widgets/choice_selector_dialog.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/choice_selector_dialog.dart
@@ -82,7 +82,7 @@ class _OptionCard extends StatelessWidget {
                   height: 64,
                   decoration: BoxDecoration(
                     color: context.colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
                   ),
                   clipBehavior: Clip.antiAlias,
                   child: imageUrl != null

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
@@ -125,7 +125,7 @@ class _PictogramGridItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -134,7 +134,7 @@ class _PictogramGridItem extends StatelessWidget {
             height: 56,
             decoration: BoxDecoration(
               color: context.colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
             ),
             clipBehavior: Clip.antiAlias,
             child: pictogram.imageUrl != null

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -156,7 +156,7 @@ class _SearchTab extends StatelessWidget {
                             : Colors.transparent,
                         width: 3,
                       ),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
                       color: context.colorScheme.surfaceContainerLow,
                     ),
                     child: Column(
@@ -325,7 +325,7 @@ class _GenerateTab extends StatelessWidget {
           contentPadding: EdgeInsets.zero,
         ),
         const SizedBox(height: 12),
-        ElevatedButton.icon(
+        FilledButton.icon(
           onPressed: isCreatingPictogram ? null : onGenerate,
           icon: isCreatingPictogram
               ? const SizedBox(
@@ -354,7 +354,7 @@ class _SelectedPictogramPreview extends StatelessWidget {
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: context.colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
         border: Border.all(color: context.colorScheme.primary, width: 2),
       ),
       child: Row(

--- a/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
@@ -72,7 +72,7 @@ class _DayColumn extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(

--- a/frontend/lib/features/weekplan/presentation/widgets/week_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/week_selector.dart
@@ -123,7 +123,7 @@ class _DayButton extends StatelessWidget {
           color: isSelected
               ? context.colorScheme.primary
               : context.colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
           border: isToday && !isSelected
               ? Border.all(
                   color: context.colorScheme.primary,

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -128,9 +128,9 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsWidgets);
       expect(find.text('Tilføj'), findsNothing);
 
-      // The ElevatedButton should be disabled
+      // The FilledButton should be disabled
       final button =
-          tester.widget<ElevatedButton>(find.byType(ElevatedButton).first);
+          tester.widget<FilledButton>(find.byType(FilledButton).first);
       expect(button.onPressed, isNull);
     });
 


### PR DESCRIPTION
## Summary

- Remove 7 hardcoded color overrides from `ColorScheme.fromSeed()` — let the orange seed generate the full M3 tonal palette (surfaces, containers, on-colors) automatically
- Replace `ElevatedButton` (M2-era) with `FilledButton` (M3) across all views and tests
- Add `CardThemeData` with `elevation: 0` — use tonal surface colors for hierarchy instead of drop shadows
- Add `GirafShape` constants (`radiusSmall: 8`, `radiusMedium: 12`, `radiusLarge: 16`) to replace magic border radius numbers
- Add `scrolledUnderElevation: 0` to AppBar theme

GIRAF orange AppBar and `GirafThemeExtension` semantic colors are unchanged.

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — all 226 tests pass
- [x] Visual verification via Chrome DevTools: login, org picker, citizen picker, week view all render correctly with new tonal surfaces
- [ ] Manual test on Android emulator
- [ ] Manual test on iOS simulator