### PR TITLE
feat: iPad landscape layout redesign

### DIFF
--- a/frontend/lib/features/organisation_picker/presentation/views/citizen_picker_view.dart
+++ b/frontend/lib/features/organisation_picker/presentation/views/citizen_picker_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/features/organisation_picker/domain/organisation_picker_state.dart';
 import 'package:weekplanner/features/organisation_picker/presentation/organisation_picker_cubit.dart';
 import 'package:weekplanner/shared/models/citizen.dart';
@@ -75,10 +76,14 @@ class _CitizenGradeList extends StatelessWidget {
       return const Center(child: Text('Ingen borgere eller grupper fundet'));
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: allItems.length,
-      itemBuilder: (context, index) {
+    return Center(
+      child: ConstrainedBox(
+        constraints:
+            const BoxConstraints(maxWidth: GirafLayout.maxNarrowWidth),
+        child: ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: allItems.length,
+          itemBuilder: (context, index) {
         final item = allItems[index];
         return Card(
           margin: const EdgeInsets.only(bottom: 12),
@@ -105,6 +110,8 @@ class _CitizenGradeList extends StatelessWidget {
           ),
         );
       },
+    ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/organisation_picker/presentation/views/organisation_picker_view.dart
+++ b/frontend/lib/features/organisation_picker/presentation/views/organisation_picker_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/features/auth/presentation/auth_cubit.dart';
 import 'package:weekplanner/features/organisation_picker/domain/organisation_picker_state.dart';
 import 'package:weekplanner/features/organisation_picker/presentation/organisation_picker_cubit.dart';
@@ -79,13 +80,19 @@ class _OrganisationList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: organisations.length,
-      itemBuilder: (context, index) {
-        final org = organisations[index];
-        return _OrgCard(org: org);
-      },
+    return Center(
+      child: ConstrainedBox(
+        constraints:
+            const BoxConstraints(maxWidth: GirafLayout.maxNarrowWidth),
+        child: ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: organisations.length,
+          itemBuilder: (context, index) {
+            final org = organisations[index];
+            return _OrgCard(org: org);
+          },
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
@@ -39,155 +40,185 @@ class ActivityFormView extends StatelessWidget {
           final cubit = context.read<ActivityFormCubit>();
           return IgnorePointer(
             ignoring: isSaving,
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // Choice activity toggle (only for new activities)
-                  if (!state.isEditing)
-                    SwitchListTile(
-                      title: const Text('Valgaktivitet'),
-                      subtitle: state.form.isChoiceActivity
-                          ? const Text('Barnet vælger mellem muligheder')
-                          : null,
-                      value: state.form.isChoiceActivity,
-                      onChanged: (_) => cubit.toggleChoiceActivity(),
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  if (!state.isEditing) const SizedBox(height: 8),
-                  if (state.form.isChoiceActivity) ...[
-                    // Choice options editor
-                    _ChoiceOptionsEditor(
-                      options: state.form.choiceOptions,
-                      cubit: cubit,
-                    ),
-                    const SizedBox(height: 16),
-                    // Title for the activity slot itself
-                    _TitleField(
-                      title: state.form.title,
-                      onChanged: cubit.setTitle,
-                    ),
-                  ] else ...[
-                    // Normal: single pictogram selector
-                    Text(
-                      'Piktogram',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    const PictogramSelector(),
-                    const SizedBox(height: 24),
-                    // Title field
-                    _TitleField(
-                      title: state.form.title,
-                      onChanged: cubit.setTitle,
-                    ),
-                  ],
-                  const SizedBox(height: 16),
-                  // Date picker
-                  _DatePicker(
-                    date: state.form.date,
-                    onTap: () async {
-                      final picked = await showDatePicker(
-                        context: context,
-                        initialDate: state.form.date,
-                        firstDate: DateTime(2020),
-                        lastDate: DateTime(2100),
-                      );
-                      if (picked != null && context.mounted) {
-                        cubit.setDate(picked);
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 16),
-                  // Repeat selector (only for new activities)
-                  if (!state.isEditing)
-                    _RepeatDaySelector(
-                      selectedDays: state.form.repeatDays,
-                      onToggleDay: cubit.toggleRepeatDay,
-                      onSelectWeekdays: cubit.setRepeatWeekdays,
-                      onClear: cubit.clearRepeatDays,
-                    ),
-                  if (!state.isEditing) const SizedBox(height: 16),
-                  // Time toggle
-                  SwitchListTile(
-                    title: const Text('Angiv tidspunkt'),
-                    value: state.form.hasTime,
-                    onChanged: (_) => cubit.toggleHasTime(),
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                  // Time pickers (only when enabled)
-                  if (state.form.hasTime) ...[
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: _TimePicker(
-                            label: 'Starttid',
-                            time: state.form.startTime,
-                            onTap: () async {
-                              final picked = await showTimePicker(
-                                context: context,
-                                initialTime: TimeOfDay(
-                                  hour: state.form.startTime.hour,
-                                  minute: state.form.startTime.minute,
-                                ),
-                              );
-                              if (picked != null && context.mounted) {
-                                cubit.setStartTime(
-                                  (hour: picked.hour, minute: picked.minute),
-                                );
-                              }
-                            },
-                          ),
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(
+                    maxWidth: GirafLayout.maxContentWidth),
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(24),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Left column: pictogram / choice options
+                      Expanded(
+                        flex: 45,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            if (!state.isEditing)
+                              SwitchListTile(
+                                title: const Text('Valgaktivitet'),
+                                subtitle: state.form.isChoiceActivity
+                                    ? const Text(
+                                        'Barnet vælger mellem muligheder')
+                                    : null,
+                                value: state.form.isChoiceActivity,
+                                onChanged: (_) =>
+                                    cubit.toggleChoiceActivity(),
+                                contentPadding: EdgeInsets.zero,
+                              ),
+                            if (!state.isEditing) const SizedBox(height: 8),
+                            if (state.form.isChoiceActivity)
+                              _ChoiceOptionsEditor(
+                                options: state.form.choiceOptions,
+                                cubit: cubit,
+                              )
+                            else ...[
+                              Text(
+                                'Piktogram',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium,
+                              ),
+                              const SizedBox(height: 8),
+                              const PictogramSelector(),
+                            ],
+                          ],
                         ),
-                        const SizedBox(width: 16),
-                        Expanded(
-                          child: _TimePicker(
-                            label: 'Sluttid',
-                            time: state.form.endTime,
-                            onTap: () async {
-                              final picked = await showTimePicker(
-                                context: context,
-                                initialTime: TimeOfDay(
-                                  hour: state.form.endTime.hour,
-                                  minute: state.form.endTime.minute,
-                                ),
-                              );
-                              if (picked != null && context.mounted) {
-                                cubit.setEndTime(
-                                  (hour: picked.hour, minute: picked.minute),
-                                );
-                              }
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                  const SizedBox(height: 24),
-                  if (error != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 16),
-                      child: Text(
-                        error,
-                        style: TextStyle(color: context.colorScheme.error),
-                        textAlign: TextAlign.center,
                       ),
-                    ),
-                  FilledButton(
-                    onPressed: isSaving
-                        ? null
-                        : () => cubit.save(),
-                    child: isSaving
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(submitLabel),
+                      const SizedBox(width: 32),
+                      // Right column: form fields
+                      Expanded(
+                        flex: 55,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _TitleField(
+                              title: state.form.title,
+                              onChanged: cubit.setTitle,
+                            ),
+                            const SizedBox(height: 16),
+                            _DatePicker(
+                              date: state.form.date,
+                              onTap: () async {
+                                final picked = await showDatePicker(
+                                  context: context,
+                                  initialDate: state.form.date,
+                                  firstDate: DateTime(2020),
+                                  lastDate: DateTime(2100),
+                                );
+                                if (picked != null && context.mounted) {
+                                  cubit.setDate(picked);
+                                }
+                              },
+                            ),
+                            const SizedBox(height: 16),
+                            if (!state.isEditing)
+                              _RepeatDaySelector(
+                                selectedDays: state.form.repeatDays,
+                                onToggleDay: cubit.toggleRepeatDay,
+                                onSelectWeekdays:
+                                    cubit.setRepeatWeekdays,
+                                onClear: cubit.clearRepeatDays,
+                              ),
+                            if (!state.isEditing)
+                              const SizedBox(height: 16),
+                            SwitchListTile(
+                              title: const Text('Angiv tidspunkt'),
+                              value: state.form.hasTime,
+                              onChanged: (_) => cubit.toggleHasTime(),
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                            if (state.form.hasTime) ...[
+                              const SizedBox(height: 8),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: _TimePicker(
+                                      label: 'Starttid',
+                                      time: state.form.startTime,
+                                      onTap: () async {
+                                        final picked =
+                                            await showTimePicker(
+                                          context: context,
+                                          initialTime: TimeOfDay(
+                                            hour: state
+                                                .form.startTime.hour,
+                                            minute: state
+                                                .form.startTime.minute,
+                                          ),
+                                        );
+                                        if (picked != null &&
+                                            context.mounted) {
+                                          cubit.setStartTime((
+                                            hour: picked.hour,
+                                            minute: picked.minute,
+                                          ));
+                                        }
+                                      },
+                                    ),
+                                  ),
+                                  const SizedBox(width: 16),
+                                  Expanded(
+                                    child: _TimePicker(
+                                      label: 'Sluttid',
+                                      time: state.form.endTime,
+                                      onTap: () async {
+                                        final picked =
+                                            await showTimePicker(
+                                          context: context,
+                                          initialTime: TimeOfDay(
+                                            hour:
+                                                state.form.endTime.hour,
+                                            minute: state
+                                                .form.endTime.minute,
+                                          ),
+                                        );
+                                        if (picked != null &&
+                                            context.mounted) {
+                                          cubit.setEndTime((
+                                            hour: picked.hour,
+                                            minute: picked.minute,
+                                          ));
+                                        }
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                            const SizedBox(height: 24),
+                            if (error != null)
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(bottom: 16),
+                                child: Text(
+                                  error,
+                                  style: TextStyle(
+                                      color: context.colorScheme.error),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            FilledButton(
+                              onPressed: isSaving
+                                  ? null
+                                  : () => cubit.save(),
+                              child: isSaving
+                                  ? const SizedBox(
+                                      height: 20,
+                                      width: 20,
+                                      child:
+                                          CircularProgressIndicator(
+                                              strokeWidth: 2),
+                                    )
+                                  : Text(submitLabel),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
           );

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -40,7 +40,8 @@ class ActivityFormView extends StatelessWidget {
           final cubit = context.read<ActivityFormCubit>();
           return IgnorePointer(
             ignoring: isSaving,
-            child: Center(
+            child: Align(
+              alignment: Alignment.topCenter,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(
                     maxWidth: GirafLayout.maxContentWidth),

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -643,6 +643,8 @@ class _ActivityList extends StatelessWidget {
                             activity: activity,
                             imageUrl: _imageUrlFor(activity),
                             soundUrl: _soundUrlFor(activity),
+                            onLongPress: () =>
+                                onLongPress(activity.activityId),
                             onChoiceTap: activity.options.isNotEmpty &&
                                     activity.selectedOptionIndex == null
                                 ? () => _showChoiceSelector(

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -622,47 +622,88 @@ class _ActivityList extends StatelessWidget {
           maxWidth: GirafLayout.maxContentWidth,
           maxHeight: 450,
         ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              for (final activity in activities)
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 6),
-                    child: isSelecting
-                        ? _SelectableTile(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final tileCount = activities.length.clamp(1, 6);
+            final totalPadding = 48.0 + (tileCount - 1) * 12.0;
+            final tileWidth =
+                (constraints.maxWidth - totalPadding) / tileCount;
+
+            if (isSelecting) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 24, vertical: 16),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (final activity in activities)
+                      Expanded(
+                        child: Padding(
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: 6),
+                          child: _SelectableTile(
                             activity: activity,
                             imageUrl: _imageUrlFor(activity),
-                            isSelected:
-                                selectedIds.contains(activity.activityId),
+                            isSelected: selectedIds
+                                .contains(activity.activityId),
                             onTap: () =>
                                 onToggleSelection(activity.activityId),
-                          )
-                        : ActivityTile(
-                            key: ValueKey(activity.activityId),
-                            activity: activity,
-                            imageUrl: _imageUrlFor(activity),
-                            soundUrl: _soundUrlFor(activity),
-                            onLongPress: () =>
-                                onLongPress(activity.activityId),
-                            onChoiceTap: activity.options.isNotEmpty &&
-                                    activity.selectedOptionIndex == null
-                                ? () => _showChoiceSelector(
-                                    context, activity, cubit)
-                                : null,
-                            onEdit: () => _editActivity(context, activity),
-                            onDelete: () =>
-                                _confirmDelete(context, activity, cubit),
-                            onToggleStatus: () =>
-                                cubit.toggleActivityStatus(
-                                    activity.activityId),
                           ),
-                  ),
+                        ),
+                      ),
+                  ],
                 ),
-            ],
-          ),
+              );
+            }
+
+            return ReorderableListView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 24, vertical: 16),
+              onReorder: cubit.reorderActivities,
+              proxyDecorator: (child, index, animation) =>
+                  AnimatedBuilder(
+                animation: animation,
+                builder: (context, child) => Material(
+                  elevation: 4,
+                  borderRadius:
+                      BorderRadius.circular(GirafShape.radiusLarge),
+                  child: child,
+                ),
+                child: child,
+              ),
+              children: [
+                for (final activity in activities)
+                  SizedBox(
+                    key: ValueKey(activity.activityId),
+                    width: tileWidth,
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 6),
+                      child: ActivityTile(
+                        activity: activity,
+                        imageUrl: _imageUrlFor(activity),
+                        soundUrl: _soundUrlFor(activity),
+                        onLongPress: () =>
+                            onLongPress(activity.activityId),
+                        onChoiceTap: activity.options.isNotEmpty &&
+                                activity.selectedOptionIndex == null
+                            ? () => _showChoiceSelector(
+                                context, activity, cubit)
+                            : null,
+                        onEdit: () =>
+                            _editActivity(context, activity),
+                        onDelete: () => _confirmDelete(
+                            context, activity, cubit),
+                        onToggleStatus: () =>
+                            cubit.toggleActivityStatus(
+                                activity.activityId),
+                      ),
+                    ),
+                  ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -5,8 +5,9 @@ import 'package:go_router/go_router.dart';
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/weekplan_cubit.dart';
-import 'package:weekplanner/features/weekplan/presentation/widgets/activity_list_item.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/activity_tile.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/choice_selector_dialog.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/week_overview.dart';
 import 'package:weekplanner/features/weekplan/presentation/widgets/week_selector.dart';
 import 'package:weekplanner/shared/models/activity.dart';
@@ -615,74 +616,74 @@ class _ActivityList extends StatelessWidget {
   Widget build(BuildContext context) {
     final cubit = context.read<WeekplanCubit>();
 
-    if (isSelecting) {
-      return ListView.builder(
-        padding: const EdgeInsets.only(top: 8, bottom: 80),
-        itemCount: activities.length,
-        itemBuilder: (context, index) {
-          final activity = activities[index];
-          final media = activity.pictogramId != null
-              ? pictogramMedia[activity.pictogramId!]
-              : null;
-          final isSelected = selectedIds.contains(activity.activityId);
-          return _SelectableActivityItem(
-            activity: activity,
-            imageUrl: media?.imageUrl,
-            isSelected: isSelected,
-            onTap: () => onToggleSelection(activity.activityId),
-          );
-        },
-      );
-    }
-
-    return ReorderableListView.builder(
-      padding: const EdgeInsets.only(top: 8, bottom: 80),
-      onReorder: cubit.reorderActivities,
-      proxyDecorator: (child, index, animation) {
-        return AnimatedBuilder(
-          animation: animation,
-          builder: (context, child) => Material(
-            elevation: 4,
-            borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
-            child: child,
+    return Center(
+      child: ConstrainedBox(
+        constraints:
+            const BoxConstraints(maxWidth: GirafLayout.maxContentWidth),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final activity in activities)
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 6),
+                    child: isSelecting
+                        ? _SelectableTile(
+                            activity: activity,
+                            imageUrl: _imageUrlFor(activity),
+                            isSelected:
+                                selectedIds.contains(activity.activityId),
+                            onTap: () =>
+                                onToggleSelection(activity.activityId),
+                          )
+                        : ActivityTile(
+                            key: ValueKey(activity.activityId),
+                            activity: activity,
+                            imageUrl: _imageUrlFor(activity),
+                            soundUrl: _soundUrlFor(activity),
+                            onChoiceTap: activity.options.isNotEmpty &&
+                                    activity.selectedOptionIndex == null
+                                ? () => _showChoiceSelector(
+                                    context, activity, cubit)
+                                : null,
+                            onEdit: () => _editActivity(context, activity),
+                            onDelete: () =>
+                                _confirmDelete(context, activity, cubit),
+                            onToggleStatus: () =>
+                                cubit.toggleActivityStatus(
+                                    activity.activityId),
+                          ),
+                  ),
+                ),
+            ],
           ),
-          child: child,
-        );
-      },
-      itemCount: activities.length,
-      itemBuilder: (context, index) {
-        final activity = activities[index];
-        final media = activity.pictogramId != null
-            ? pictogramMedia[activity.pictogramId!]
-            : null;
-        return ActivityListItem(
-          key: ValueKey(activity.activityId),
-          activity: activity,
-          imageUrl: media?.imageUrl,
-          soundUrl: media?.soundUrl,
-          onLongPress: () => onLongPress(activity.activityId),
-          onChoiceTap: activity.options.isNotEmpty &&
-                  activity.selectedOptionIndex == null
-              ? () => _showChoiceSelector(context, activity, cubit)
-              : null,
-          onEdit: () async {
-            final dateStr =
-                activity.date.toIso8601String().split('T').first;
-            final saved = await context.push<bool>(
-              '/weekplan/$citizenId/edit/${activity.activityId}'
-              '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
-              extra: activity,
-            );
-            if (saved == true && context.mounted) {
-              context.read<WeekplanCubit>().loadActivities();
-            }
-          },
-          onDelete: () => _confirmDelete(context, activity, cubit),
-          onToggleStatus: () =>
-              cubit.toggleActivityStatus(activity.activityId),
-        );
-      },
+        ),
+      ),
     );
+  }
+
+  String? _imageUrlFor(Activity activity) {
+    if (activity.pictogramId == null) return null;
+    return pictogramMedia[activity.pictogramId!]?.imageUrl;
+  }
+
+  String? _soundUrlFor(Activity activity) {
+    if (activity.pictogramId == null) return null;
+    return pictogramMedia[activity.pictogramId!]?.soundUrl;
+  }
+
+  Future<void> _editActivity(BuildContext context, Activity activity) async {
+    final dateStr = activity.date.toIso8601String().split('T').first;
+    final saved = await context.push<bool>(
+      '/weekplan/$citizenId/edit/${activity.activityId}'
+      '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
+      extra: activity,
+    );
+    if (saved == true && context.mounted) {
+      context.read<WeekplanCubit>().loadActivities();
+    }
   }
 
   Future<void> _confirmDelete(
@@ -761,15 +762,15 @@ class _ActivityList extends StatelessWidget {
   }
 }
 
-// ── Selectable activity item (selection mode) ─────────────
+// ── Selectable activity tile (selection mode) ───────────────
 
-class _SelectableActivityItem extends StatelessWidget {
+class _SelectableTile extends StatelessWidget {
   final Activity activity;
   final String? imageUrl;
   final bool isSelected;
   final VoidCallback onTap;
 
-  const _SelectableActivityItem({
+  const _SelectableTile({
     required this.activity,
     this.imageUrl,
     required this.isSelected,
@@ -778,61 +779,75 @@ class _SelectableActivityItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    final hasPictogram = activity.pictogramId != null;
+
+    return GestureDetector(
+      onTap: onTap,
       child: Card(
-        color: isSelected
-            ? context.colorScheme.primaryContainer
-            : null,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
+        clipBehavior: Clip.antiAlias,
+        color: isSelected ? context.colorScheme.primaryContainer : null,
+        child: Stack(
+          children: [
+            Column(
               children: [
-                Checkbox(
-                  value: isSelected,
-                  onChanged: (_) => onTap(),
-                ),
-                const SizedBox(width: 8),
-                // Pictogram thumbnail
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    color: context.colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
-                  ),
-                  clipBehavior: Clip.antiAlias,
-                  child: imageUrl != null
+                Expanded(
+                  child: imageUrl != null && hasPictogram
                       ? Image.network(
                           imageUrl!,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, _, _) => Icon(
-                            Icons.image,
-                            size: 24,
-                            color: context.colorScheme.onPrimaryContainer,
+                          width: double.infinity,
+                          errorBuilder: (_, _, _) => Center(
+                            child: Icon(
+                              Icons.image,
+                              size: 48,
+                              color: context.colorScheme.onPrimaryContainer,
+                            ),
                           ),
                         )
-                      : Icon(
-                          Icons.event,
-                          size: 24,
-                          color: context.colorScheme.onPrimaryContainer,
+                      : Container(
+                          color: context.colorScheme.primaryContainer,
+                          child: Center(
+                            child: Icon(
+                              hasPictogram ? Icons.image : Icons.event,
+                              size: 48,
+                              color: context.colorScheme.onPrimaryContainer,
+                            ),
+                          ),
                         ),
                 ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    activity.title ?? 'Unavngivet aktivitet',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
+                Container(
+                  height: GirafLayout.tileLabelHeight,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  color: context.colorScheme.surfaceContainerLow,
+                  child: Center(
+                    child: Text(
+                      activity.title ?? 'Unavngivet',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
                   ),
                 ),
               ],
             ),
-          ),
+            Positioned(
+              top: 8,
+              left: 8,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: context.colorScheme.surface.withAlpha(200),
+                  shape: BoxShape.circle,
+                ),
+                child: Checkbox(
+                  value: isSelected,
+                  onChanged: (_) => onTap(),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -618,8 +618,10 @@ class _ActivityList extends StatelessWidget {
 
     return Center(
       child: ConstrainedBox(
-        constraints:
-            const BoxConstraints(maxWidth: GirafLayout.maxContentWidth),
+        constraints: const BoxConstraints(
+          maxWidth: GirafLayout.maxContentWidth,
+          maxHeight: 450,
+        ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
           child: Row(

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
@@ -1,0 +1,287 @@
+import 'dart:async';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
+import 'package:weekplanner/shared/models/activity.dart';
+import 'package:weekplanner/shared/utils/date_utils.dart';
+
+/// Pictogram-dominant activity tile for the day view.
+///
+/// The pictogram fills most of the card. A small label strip at the bottom
+/// shows the title and optional time range. Designed for iPad landscape
+/// where 6 tiles sit side-by-side in a single row.
+class ActivityTile extends StatefulWidget {
+  final Activity activity;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onToggleStatus;
+  final VoidCallback? onChoiceTap;
+  final String? imageUrl;
+  final String? soundUrl;
+
+  const ActivityTile({
+    super.key,
+    required this.activity,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onToggleStatus,
+    this.onChoiceTap,
+    this.imageUrl,
+    this.soundUrl,
+  });
+
+  @override
+  State<ActivityTile> createState() => _ActivityTileState();
+}
+
+class _ActivityTileState extends State<ActivityTile> {
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  late final StreamSubscription _onCompleteSubscription;
+  final ValueNotifier<bool> _isPlaying = ValueNotifier(false);
+
+  @override
+  void initState() {
+    super.initState();
+    _onCompleteSubscription = _audioPlayer.onPlayerComplete.listen((_) {
+      _isPlaying.value = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _onCompleteSubscription.cancel();
+    _audioPlayer.dispose();
+    _isPlaying.dispose();
+    super.dispose();
+  }
+
+  Future<void> _togglePlayback() async {
+    if (_isPlaying.value) {
+      await _audioPlayer.stop();
+      _isPlaying.value = false;
+    } else {
+      final url = widget.soundUrl;
+      if (url != null && url.isNotEmpty) {
+        await _audioPlayer.play(UrlSource(url));
+        _isPlaying.value = true;
+      }
+    }
+  }
+
+  void _showContextMenu(BuildContext context) {
+    final renderBox = context.findRenderObject()! as RenderBox;
+    final offset = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        offset.dx,
+        offset.dy + size.height,
+        offset.dx + size.width,
+        offset.dy,
+      ),
+      items: [
+        const PopupMenuItem(value: 'edit', child: Text('Rediger')),
+        const PopupMenuItem(value: 'delete', child: Text('Slet')),
+      ],
+    ).then((value) {
+      if (!mounted) return;
+      switch (value) {
+        case 'edit':
+          widget.onEdit();
+        case 'delete':
+          widget.onDelete();
+        default:
+          break;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final activity = widget.activity;
+    final isUnresolvedChoice =
+        activity.options.isNotEmpty && activity.selectedOptionIndex == null;
+    final hasSound =
+        widget.soundUrl != null && widget.soundUrl!.isNotEmpty;
+
+    final cardColor = activity.isCompleted
+        ? context.girafColors.completedBackground
+        : isUnresolvedChoice
+            ? context.colorScheme.tertiaryContainer
+            : context.girafColors.pendingBackground;
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      color: cardColor,
+      child: InkWell(
+        onTap: isUnresolvedChoice
+            ? widget.onChoiceTap
+            : hasSound
+                ? _togglePlayback
+                : widget.onToggleStatus,
+        onLongPress: () => _showContextMenu(context),
+        child: Column(
+          children: [
+            Expanded(child: _TilePictogram(this)),
+            _TileLabel(activity: activity),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TilePictogram extends StatelessWidget {
+  final _ActivityTileState state;
+
+  const _TilePictogram(this.state);
+
+  @override
+  Widget build(BuildContext context) {
+    final activity = state.widget.activity;
+    final imageUrl = state.widget.imageUrl;
+    final hasPictogram = activity.pictogramId != null;
+    final isUnresolvedChoice =
+        activity.options.isNotEmpty && activity.selectedOptionIndex == null;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Pictogram image or placeholder
+        if (imageUrl != null && hasPictogram)
+          Image.network(
+            imageUrl,
+            fit: BoxFit.cover,
+            errorBuilder: (_, _, _) => _PictogramPlaceholder(
+              icon: Icons.image,
+            ),
+          )
+        else
+          _PictogramPlaceholder(
+            icon: hasPictogram ? Icons.image : Icons.event,
+          ),
+
+        // Completion indicator (top-right)
+        if (activity.isCompleted)
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                color: context.girafColors.completedIndicator,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.check,
+                size: 20,
+                color: context.colorScheme.onPrimary,
+              ),
+            ),
+          ),
+
+        // Choice badge (bottom-right)
+        if (isUnresolvedChoice)
+          Positioned(
+            bottom: 8,
+            right: 8,
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                color: context.colorScheme.tertiary,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.touch_app,
+                size: 16,
+                color: context.colorScheme.onTertiary,
+              ),
+            ),
+          ),
+
+        // Sound indicator (top-left)
+        if (state.widget.soundUrl != null &&
+            state.widget.soundUrl!.isNotEmpty)
+          Positioned(
+            top: 8,
+            left: 8,
+            child: ValueListenableBuilder<bool>(
+              valueListenable: state._isPlaying,
+              builder: (context, isPlaying, _) => Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  color: context.colorScheme.surface.withAlpha(200),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  isPlaying ? Icons.volume_up : Icons.volume_off,
+                  size: 16,
+                  color: context.colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _PictogramPlaceholder extends StatelessWidget {
+  final IconData icon;
+
+  const _PictogramPlaceholder({required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: context.colorScheme.primaryContainer,
+      child: Center(
+        child: Icon(
+          icon,
+          size: 48,
+          color: context.colorScheme.onPrimaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+class _TileLabel extends StatelessWidget {
+  final Activity activity;
+
+  const _TileLabel({required this.activity});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: GirafLayout.tileLabelHeight,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      color: context.colorScheme.surfaceContainerLow,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            activity.title ?? 'Unavngivet',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          if (activity.startTime case final start?)
+            if (activity.endTime case final end?)
+              Text(
+                '${formatTimeValue(start)} - ${formatTimeValue(end)}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.colorScheme.outline,
+                    ),
+              ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
@@ -124,12 +124,15 @@ class _ActivityTileState extends State<ActivityTile> {
             ? widget.onChoiceTap
             : hasSound
                 ? _togglePlayback
-                : widget.onToggleStatus,
+                : null,
         onLongPress: widget.onLongPress ?? () => _showContextMenu(context),
         child: Column(
           children: [
             Expanded(child: _TilePictogram(this)),
-            _TileLabel(activity: activity),
+            _TileLabel(
+              activity: activity,
+              onToggleStatus: widget.onToggleStatus,
+            ),
           ],
         ),
       ),
@@ -254,34 +257,60 @@ class _PictogramPlaceholder extends StatelessWidget {
 
 class _TileLabel extends StatelessWidget {
   final Activity activity;
+  final VoidCallback onToggleStatus;
 
-  const _TileLabel({required this.activity});
+  const _TileLabel({
+    required this.activity,
+    required this.onToggleStatus,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       height: GirafLayout.tileLabelHeight,
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding: const EdgeInsets.only(left: 8, right: 2, top: 4, bottom: 4),
       color: context.colorScheme.surfaceContainerLow,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+      child: Row(
         children: [
-          Text(
-            activity.title ?? 'Unavngivet',
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  activity.title ?? 'Unavngivet',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                 ),
-          ),
-          if (activity.startTime case final start?)
-            if (activity.endTime case final end?)
-              Text(
-                '${formatTimeValue(start)} - ${formatTimeValue(end)}',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: context.colorScheme.outline,
+                if (activity.startTime case final start?)
+                  if (activity.endTime case final end?)
+                    Text(
+                      '${formatTimeValue(start)} - ${formatTimeValue(end)}',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.colorScheme.outline,
+                          ),
                     ),
-              ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: onToggleStatus,
+            icon: Icon(
+              activity.isCompleted
+                  ? Icons.check_circle
+                  : Icons.circle_outlined,
+              color: activity.isCompleted
+                  ? context.girafColors.completedIndicator
+                  : context.colorScheme.outline,
+            ),
+            tooltip: activity.isCompleted ? 'Ikke færdig' : 'Færdig',
+            iconSize: 28,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+          ),
         ],
       ),
     );

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
@@ -72,12 +72,13 @@ class _ActivityTileState extends State<ActivityTile> {
     }
   }
 
-  void _showContextMenu(BuildContext context) {
+  Future<void> _showContextMenu(BuildContext context) async {
+    // Non-null: only called from onLongPress, so widget is laid out.
     final renderBox = context.findRenderObject()! as RenderBox;
     final offset = renderBox.localToGlobal(Offset.zero);
     final size = renderBox.size;
 
-    showMenu<String>(
+    final value = await showMenu<String>(
       context: context,
       position: RelativeRect.fromLTRB(
         offset.dx,
@@ -89,17 +90,16 @@ class _ActivityTileState extends State<ActivityTile> {
         const PopupMenuItem(value: 'edit', child: Text('Rediger')),
         const PopupMenuItem(value: 'delete', child: Text('Slet')),
       ],
-    ).then((value) {
-      if (!mounted) return;
-      switch (value) {
-        case 'edit':
-          widget.onEdit();
-        case 'delete':
-          widget.onDelete();
-        default:
-          break;
-      }
-    });
+    );
+    if (!mounted) return;
+    switch (value) {
+      case 'edit':
+        widget.onEdit();
+      case 'delete':
+        widget.onDelete();
+      default:
+        break;
+    }
   }
 
   @override
@@ -128,7 +128,16 @@ class _ActivityTileState extends State<ActivityTile> {
         onLongPress: widget.onLongPress ?? () => _showContextMenu(context),
         child: Column(
           children: [
-            Expanded(child: _TilePictogram(this)),
+            Expanded(
+              child: _TilePictogram(
+                imageUrl: widget.imageUrl,
+                hasPictogram: activity.pictogramId != null,
+                isCompleted: activity.isCompleted,
+                isUnresolvedChoice: isUnresolvedChoice,
+                hasSound: hasSound,
+                isPlaying: _isPlaying,
+              ),
+            ),
             _TileLabel(
               activity: activity,
               onToggleStatus: widget.onToggleStatus,
@@ -141,25 +150,31 @@ class _ActivityTileState extends State<ActivityTile> {
 }
 
 class _TilePictogram extends StatelessWidget {
-  final _ActivityTileState state;
+  final String? imageUrl;
+  final bool hasPictogram;
+  final bool isCompleted;
+  final bool isUnresolvedChoice;
+  final bool hasSound;
+  final ValueNotifier<bool> isPlaying;
 
-  const _TilePictogram(this.state);
+  const _TilePictogram({
+    required this.imageUrl,
+    required this.hasPictogram,
+    required this.isCompleted,
+    required this.isUnresolvedChoice,
+    required this.hasSound,
+    required this.isPlaying,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final activity = state.widget.activity;
-    final imageUrl = state.widget.imageUrl;
-    final hasPictogram = activity.pictogramId != null;
-    final isUnresolvedChoice =
-        activity.options.isNotEmpty && activity.selectedOptionIndex == null;
-
     return Stack(
       fit: StackFit.expand,
       children: [
         // Pictogram image or placeholder
         if (imageUrl != null && hasPictogram)
           Image.network(
-            imageUrl,
+            imageUrl!,
             fit: BoxFit.cover,
             errorBuilder: (_, _, _) => _PictogramPlaceholder(
               icon: Icons.image,
@@ -171,7 +186,7 @@ class _TilePictogram extends StatelessWidget {
           ),
 
         // Completion indicator (top-right)
-        if (activity.isCompleted)
+        if (isCompleted)
           Positioned(
             top: 8,
             right: 8,
@@ -209,21 +224,20 @@ class _TilePictogram extends StatelessWidget {
           ),
 
         // Sound indicator (top-left)
-        if (state.widget.soundUrl != null &&
-            state.widget.soundUrl!.isNotEmpty)
+        if (hasSound)
           Positioned(
             top: 8,
             left: 8,
             child: ValueListenableBuilder<bool>(
-              valueListenable: state._isPlaying,
-              builder: (context, isPlaying, _) => Container(
+              valueListenable: isPlaying,
+              builder: (context, playing, _) => Container(
                 padding: const EdgeInsets.all(4),
                 decoration: BoxDecoration(
                   color: context.colorScheme.surface.withAlpha(200),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
-                  isPlaying ? Icons.volume_up : Icons.volume_off,
+                  playing ? Icons.volume_up : Icons.volume_off,
                   size: 16,
                   color: context.colorScheme.onSurface,
                 ),

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
@@ -17,6 +17,7 @@ class ActivityTile extends StatefulWidget {
   final VoidCallback onEdit;
   final VoidCallback onDelete;
   final VoidCallback onToggleStatus;
+  final VoidCallback? onLongPress;
   final VoidCallback? onChoiceTap;
   final String? imageUrl;
   final String? soundUrl;
@@ -27,6 +28,7 @@ class ActivityTile extends StatefulWidget {
     required this.onEdit,
     required this.onDelete,
     required this.onToggleStatus,
+    this.onLongPress,
     this.onChoiceTap,
     this.imageUrl,
     this.soundUrl,
@@ -123,7 +125,7 @@ class _ActivityTileState extends State<ActivityTile> {
             : hasSound
                 ? _togglePlayback
                 : widget.onToggleStatus,
-        onLongPress: () => _showContextMenu(context),
+        onLongPress: widget.onLongPress ?? () => _showContextMenu(context),
         child: Column(
           children: [
             Expanded(child: _TilePictogram(this)),

--- a/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/week_overview.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/weekplan_state.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/shared/models/activity.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
@@ -30,20 +31,33 @@ class WeekOverview extends StatelessWidget {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      itemCount: weekDates.length,
-      itemBuilder: (context, index) {
-        final date = weekDates[index];
-        final dateKey = GirafDateUtils.formatQueryDate(date);
-        final activities = weekActivities[dateKey] ?? const [];
-        return _DayColumn(
-          date: date,
-          activities: activities,
-          pictogramMedia: pictogramMedia,
-          onTap: () => onSelectDay(date),
-        );
-      },
+    return Center(
+      child: ConstrainedBox(
+        constraints:
+            const BoxConstraints(maxWidth: GirafLayout.maxContentWidth),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (final date in weekDates)
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: _DayColumn(
+                      date: date,
+                      activities: weekActivities[
+                              GirafDateUtils.formatQueryDate(date)] ??
+                          const [],
+                      pictogramMedia: pictogramMedia,
+                      onTap: () => onSelectDay(date),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }
@@ -69,21 +83,27 @@ class _DayColumn extends StatelessWidget {
         date.year == now.year;
 
     return Card(
-      margin: const EdgeInsets.only(bottom: 8),
+      shape: isToday
+          ? RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(GirafShape.radiusLarge),
+              side: BorderSide(color: context.colorScheme.primary, width: 2),
+            )
+          : null,
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(GirafShape.radiusMedium),
+        borderRadius: BorderRadius.circular(GirafShape.radiusLarge),
         child: Padding(
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.all(8),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               _DayHeader(date: date, isToday: isToday),
+              const SizedBox(height: 4),
               if (activities.isEmpty)
                 Padding(
                   padding: const EdgeInsets.only(top: 8),
                   child: Text(
-                    'Ingen aktiviteter',
+                    'Ingen',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: context.colorScheme.outline,
                           fontStyle: FontStyle.italic,
@@ -115,36 +135,21 @@ class _DayHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Column(
       children: [
         Text(
-          '${GirafDateUtils.dayName(date.weekday)} ${GirafDateUtils.formatDateDDMM(date)}',
-          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          GirafDateUtils.dayNameShort(date.weekday),
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: isToday ? context.colorScheme.primary : context.colorScheme.outline,
+              ),
+        ),
+        Text(
+          '${date.day}',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
                 color: isToday ? context.colorScheme.primary : null,
               ),
-        ),
-        if (isToday) ...[
-          const SizedBox(width: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: context.colorScheme.primary,
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              'I dag',
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: context.colorScheme.onPrimary,
-                  ),
-            ),
-          ),
-        ],
-        const Spacer(),
-        Icon(
-          Icons.chevron_right,
-          color: context.colorScheme.outline,
-          size: 20,
         ),
       ],
     );
@@ -163,18 +168,17 @@ class _ActivityRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(top: 6),
-      child: Row(
+      padding: const EdgeInsets.only(top: 4),
+      child: Stack(
         children: [
-          // Small pictogram thumbnail
           Container(
-            width: 32,
-            height: 32,
+            width: double.infinity,
+            height: 48,
             decoration: BoxDecoration(
               color: activity.isCompleted
                   ? context.girafColors.completedBackground
                   : context.colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(6),
+              borderRadius: BorderRadius.circular(GirafShape.radiusSmall),
             ),
             clipBehavior: Clip.antiAlias,
             child: imageUrl != null
@@ -183,37 +187,27 @@ class _ActivityRow extends StatelessWidget {
                     fit: BoxFit.cover,
                     errorBuilder: (_, _, _) => Icon(
                       Icons.image,
-                      size: 16,
+                      size: 20,
                       color: context.colorScheme.onPrimaryContainer,
                     ),
                   )
-                : Icon(
-                    Icons.event,
-                    size: 16,
-                    color: context.colorScheme.onPrimaryContainer,
+                : Center(
+                    child: Icon(
+                      Icons.event,
+                      size: 20,
+                      color: context.colorScheme.onPrimaryContainer,
+                    ),
                   ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              activity.title ?? 'Unavngivet aktivitet',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    decoration: activity.isCompleted
-                        ? TextDecoration.lineThrough
-                        : null,
-                    color: activity.isCompleted
-                        ? context.colorScheme.outline
-                        : null,
-                  ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
           ),
           if (activity.isCompleted)
-            Icon(
-              Icons.check_circle,
-              size: 16,
-              color: context.girafColors.completedIndicator,
+            Positioned(
+              top: 2,
+              right: 2,
+              child: Icon(
+                Icons.check_circle,
+                size: 14,
+                color: context.girafColors.completedIndicator,
+              ),
             ),
         ],
       ),

--- a/frontend/lib/features/weekplan/presentation/widgets/week_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/week_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/shared/layout_constants.dart';
 import 'package:weekplanner/shared/utils/date_utils.dart';
 
 class WeekSelector extends StatelessWidget {
@@ -30,10 +31,14 @@ class WeekSelector extends StatelessWidget {
     return Column(
       children: [
         // Week navigation
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        Center(
+          child: ConstrainedBox(
+            constraints:
+                const BoxConstraints(maxWidth: GirafLayout.maxContentWidth),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               IconButton(
                 icon: const Icon(Icons.chevron_left),
@@ -69,27 +74,27 @@ class WeekSelector extends StatelessWidget {
             ],
           ),
         ),
-        // Day buttons
+          ),
+        ),
+        // Day buttons — centered row of larger buttons
         SizedBox(
-          height: 64,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            itemCount: weekDates.length,
-            itemBuilder: (context, index) {
-              final date = weekDates[index];
-              final isSelected = _isSameDay(date, selectedDate);
-              final isToday = _isSameDay(date, now);
-              return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: _DayButton(
-                  date: date,
-                  isSelected: isSelected,
-                  isToday: isToday,
-                  onTap: () => onSelectDate(date),
-                ),
-              );
-            },
+          height: 80,
+          child: Center(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final date in weekDates)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 6),
+                    child: _DayButton(
+                      date: date,
+                      isSelected: _isSameDay(date, selectedDate),
+                      isToday: _isSameDay(date, now),
+                      onTap: () => onSelectDate(date),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ],
@@ -118,7 +123,7 @@ class _DayButton extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 48,
+        width: GirafLayout.daySelectorSize,
         decoration: BoxDecoration(
           color: isSelected
               ? context.colorScheme.primary
@@ -137,7 +142,7 @@ class _DayButton extends StatelessWidget {
             Text(
               GirafDateUtils.dayNameShort(date.weekday),
               style: TextStyle(
-                fontSize: 11,
+                fontSize: 14,
                 fontWeight: FontWeight.w600,
                 color: isSelected
                     ? context.colorScheme.onPrimary
@@ -148,7 +153,7 @@ class _DayButton extends StatelessWidget {
             Text(
               '${date.day}',
               style: TextStyle(
-                fontSize: 16,
+                fontSize: 20,
                 fontWeight: FontWeight.bold,
                 color: isSelected
                     ? context.colorScheme.onPrimary

--- a/frontend/lib/shared/layout_constants.dart
+++ b/frontend/lib/shared/layout_constants.dart
@@ -1,0 +1,18 @@
+/// Layout constants for the GIRAF tablet landscape design.
+///
+/// All Flutter apps in the GIRAF platform target iPad/iPhone in landscape
+/// orientation (1024×768 baseline). These constants ensure consistent
+/// content widths and sizing across screens.
+class GirafLayout {
+  /// Maximum width for the main content area (day view, week overview).
+  static const double maxContentWidth = 900.0;
+
+  /// Maximum width for narrow screens (org/citizen pickers).
+  static const double maxNarrowWidth = 700.0;
+
+  /// Height of the label strip at the bottom of activity tiles.
+  static const double tileLabelHeight = 48.0;
+
+  /// Size of each day selector button (Mon–Sun).
+  static const double daySelectorSize = 72.0;
+}

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -144,7 +144,8 @@ void main() {
       expect(find.text('Ugeplan'), findsOneWidget);
     });
 
-    testWidgets('delete shows confirmation dialog', (tester) async {
+    testWidgets('delete via selection mode shows confirmation dialog',
+        (tester) async {
       final activities = [
         Activity(
           activityId: 1,
@@ -160,20 +161,16 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      // Swipe to reveal delete action
-      await tester.drag(find.text('Morgenmad'), const Offset(-300, 0));
+      // Long-press to enter selection mode (auto-selects the activity)
+      await tester.longPress(find.text('Morgenmad'));
       await tester.pumpAndSettle();
 
-      // Tap delete
-      await tester.tap(find.text('Slet').last);
+      // Tap "Slet" in the selection action bar
+      await tester.tap(find.text('Slet'));
       await tester.pumpAndSettle();
 
       // Confirmation dialog should appear
-      expect(find.text('Slet aktivitet'), findsOneWidget);
-      expect(
-        find.text('Er du sikker på du vil slette "Morgenmad"?'),
-        findsOneWidget,
-      );
+      expect(find.text('Slet aktiviteter'), findsOneWidget);
       expect(find.text('Annuller'), findsOneWidget);
     });
 
@@ -193,13 +190,11 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      // Swipe and tap delete
-      await tester.drag(find.text('Morgenmad'), const Offset(-300, 0));
+      // Long-press → select → Slet → confirm
+      await tester.longPress(find.text('Morgenmad'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Slet').last);
+      await tester.tap(find.text('Slet'));
       await tester.pumpAndSettle();
-
-      // Tap confirm "Slet" in dialog
       await tester.tap(find.text('Slet').last);
       await tester.pumpAndSettle();
 
@@ -224,10 +219,10 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      // Swipe → delete → confirm
-      await tester.drag(find.text('Morgenmad'), const Offset(-300, 0));
+      // Long-press → select → Slet → confirm
+      await tester.longPress(find.text('Morgenmad'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Slet').last);
+      await tester.tap(find.text('Slet'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Slet').last);
       await tester.pumpAndSettle();
@@ -255,13 +250,11 @@ void main() {
 
       await tester.pumpWidget(buildSubject());
 
-      // Swipe and tap delete
-      await tester.drag(find.text('Morgenmad'), const Offset(-300, 0));
+      // Long-press → select → Slet → cancel
+      await tester.longPress(find.text('Morgenmad'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Slet').last);
+      await tester.tap(find.text('Slet'));
       await tester.pumpAndSettle();
-
-      // Tap cancel
       await tester.tap(find.text('Annuller'));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

Redesigns the weekplanner UI for iPad landscape (1024x768) — the target device for GIRAF.

- **Day view**: Replace vertical activity list with horizontal row of pictogram-dominant tiles. The pictogram fills the card with a small label strip at bottom. 6 tiles side-by-side.
- **Week overview**: Replace vertical scrolling day cards with 7 side-by-side columns showing pictogram thumbnails. Today's column highlighted.
- **Week selector**: Day buttons enlarged (48→72px), fonts scaled up, centered row instead of left-aligned horizontal scroll.
- **Activity form**: Two-column layout — pictogram selector (left 45%), form fields (right 55%).
- **Org/citizen pickers**: Content constrained to 700px max width, centered.
- **All screens**: Content constrained to 900px max width via `GirafLayout` constants.

Swipe-to-delete replaced by selection mode flow (long-press → select → bulk actions).

## New files

- `lib/shared/layout_constants.dart` — `GirafLayout` with shared sizing constants
- `lib/features/weekplan/presentation/widgets/activity_tile.dart` — pictogram-dominant tile widget

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — all 226 tests pass (delete tests updated for new selection-mode flow)
- [ ] Visual verification on iPad landscape (1024x768) via Chrome DevTools
- [ ] Manual test on iPad simulator