### PR TITLE
fix(weekplan): add edit action to day-view selection bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Schedule management app for the GIRAF ecosystem — helps children with autism manage their weekly activities using pictograms.
 
+**Target device:** iPad or iPhone in **landscape orientation**. All UI design and testing should assume a horizontal layout.
+
 ## Architecture
 
 ```

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -155,6 +155,7 @@ class _WeekplanViewState extends State<WeekplanView> {
               selectedIds: _selectedIds,
               citizenId: widget.citizenId,
               isCitizen: widget.isCitizen,
+              orgId: widget.orgId,
               onDone: () => setState(_exitSelectionMode),
             )
           : null,
@@ -275,21 +276,29 @@ class _SelectionActionBar extends StatelessWidget {
   final Set<int> selectedIds;
   final int citizenId;
   final bool isCitizen;
+  final int? orgId;
   final VoidCallback onDone;
 
   const _SelectionActionBar({
     required this.selectedIds,
     required this.citizenId,
     required this.isCitizen,
+    required this.orgId,
     required this.onDone,
   });
 
   @override
   Widget build(BuildContext context) {
+    final canEdit = selectedIds.length == 1;
     return BottomAppBar(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
+          _ActionButton(
+            icon: Icons.edit_outlined,
+            label: 'Rediger',
+            onTap: canEdit ? () => _editSelected(context) : null,
+          ),
           _ActionButton(
             icon: Icons.delete_outline,
             label: 'Slet',
@@ -309,6 +318,30 @@ class _SelectionActionBar extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _editSelected(BuildContext context) async {
+    if (selectedIds.length != 1) return;
+    final cubit = context.read<WeekplanCubit>();
+    final state = cubit.state;
+    if (state is! WeekplanLoaded) return;
+    final activityId = selectedIds.first;
+    final idx =
+        state.activities.indexWhere((a) => a.activityId == activityId);
+    if (idx == -1) return;
+    final activity = state.activities[idx];
+    final dateStr = activity.date.toIso8601String().split('T').first;
+
+    onDone();
+    if (!context.mounted) return;
+    final saved = await context.push<bool>(
+      '/weekplan/$citizenId/edit/${activity.activityId}'
+      '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
+      extra: activity,
+    );
+    if (saved == true && context.mounted) {
+      cubit.loadActivities();
+    }
   }
 
   Future<void> _bulkDelete(BuildContext context) async {
@@ -438,7 +471,7 @@ class _ActionButton extends StatelessWidget {
   final IconData icon;
   final String label;
   final Color? color;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   const _ActionButton({
     required this.icon,
@@ -449,7 +482,10 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final effectiveColor = color ?? Theme.of(context).colorScheme.primary;
+    final isEnabled = onTap != null;
+    final activeColor = color ?? Theme.of(context).colorScheme.primary;
+    final effectiveColor =
+        isEnabled ? activeColor : Theme.of(context).disabledColor;
     return TextButton.icon(
       onPressed: onTap,
       icon: Icon(icon, color: effectiveColor),
@@ -691,10 +727,6 @@ class _ActivityList extends StatelessWidget {
                             ? () => _showChoiceSelector(
                                 context, activity, cubit)
                             : null,
-                        onEdit: () =>
-                            _editActivity(context, activity),
-                        onDelete: () => _confirmDelete(
-                            context, activity, cubit),
                         onToggleStatus: () =>
                             cubit.toggleActivityStatus(
                                 activity.activityId),
@@ -717,73 +749,6 @@ class _ActivityList extends StatelessWidget {
   String? _soundUrlFor(Activity activity) {
     if (activity.pictogramId == null) return null;
     return pictogramMedia[activity.pictogramId!]?.soundUrl;
-  }
-
-  Future<void> _editActivity(BuildContext context, Activity activity) async {
-    final dateStr = activity.date.toIso8601String().split('T').first;
-    final saved = await context.push<bool>(
-      '/weekplan/$citizenId/edit/${activity.activityId}'
-      '?type=${isCitizen ? 'citizen' : 'grade'}&orgId=$orgId&date=$dateStr',
-      extra: activity,
-    );
-    if (saved == true && context.mounted) {
-      context.read<WeekplanCubit>().loadActivities();
-    }
-  }
-
-  Future<void> _confirmDelete(
-    BuildContext context,
-    Activity activity,
-    WeekplanCubit cubit,
-  ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Slet aktivitet'),
-        content: Text(
-          'Er du sikker på du vil slette "${activity.title ?? 'denne aktivitet'}"?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Annuller'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(
-              'Slet',
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
-            ),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true || !context.mounted) return;
-
-    final removed = cubit.hideActivity(activity.activityId);
-    if (removed == null || !context.mounted) return;
-
-    var undone = false;
-    ScaffoldMessenger.of(context).clearSnackBars();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          'Aktivitet "${activity.title ?? 'denne aktivitet'}" slettet',
-        ),
-        duration: const Duration(seconds: 5),
-        action: SnackBarAction(
-          label: 'Fortryd',
-          onPressed: () {
-            undone = true;
-            cubit.restoreActivity(removed);
-          },
-        ),
-      ),
-    ).closed.then((_) {
-      if (!undone && context.mounted) {
-        cubit.confirmDelete(activity.activityId, removed);
-      }
-    });
   }
 
   Future<void> _showChoiceSelector(

--- a/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/activity_tile.dart
@@ -14,10 +14,8 @@ import 'package:weekplanner/shared/utils/date_utils.dart';
 /// where 6 tiles sit side-by-side in a single row.
 class ActivityTile extends StatefulWidget {
   final Activity activity;
-  final VoidCallback onEdit;
-  final VoidCallback onDelete;
   final VoidCallback onToggleStatus;
-  final VoidCallback? onLongPress;
+  final VoidCallback onLongPress;
   final VoidCallback? onChoiceTap;
   final String? imageUrl;
   final String? soundUrl;
@@ -25,10 +23,8 @@ class ActivityTile extends StatefulWidget {
   const ActivityTile({
     super.key,
     required this.activity,
-    required this.onEdit,
-    required this.onDelete,
     required this.onToggleStatus,
-    this.onLongPress,
+    required this.onLongPress,
     this.onChoiceTap,
     this.imageUrl,
     this.soundUrl,
@@ -72,36 +68,6 @@ class _ActivityTileState extends State<ActivityTile> {
     }
   }
 
-  Future<void> _showContextMenu(BuildContext context) async {
-    // Non-null: only called from onLongPress, so widget is laid out.
-    final renderBox = context.findRenderObject()! as RenderBox;
-    final offset = renderBox.localToGlobal(Offset.zero);
-    final size = renderBox.size;
-
-    final value = await showMenu<String>(
-      context: context,
-      position: RelativeRect.fromLTRB(
-        offset.dx,
-        offset.dy + size.height,
-        offset.dx + size.width,
-        offset.dy,
-      ),
-      items: [
-        const PopupMenuItem(value: 'edit', child: Text('Rediger')),
-        const PopupMenuItem(value: 'delete', child: Text('Slet')),
-      ],
-    );
-    if (!mounted) return;
-    switch (value) {
-      case 'edit':
-        widget.onEdit();
-      case 'delete':
-        widget.onDelete();
-      default:
-        break;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final activity = widget.activity;
@@ -125,7 +91,7 @@ class _ActivityTileState extends State<ActivityTile> {
             : hasSound
                 ? _togglePlayback
                 : null,
-        onLongPress: widget.onLongPress ?? () => _showContextMenu(context),
+        onLongPress: widget.onLongPress,
         child: Column(
           children: [
             Expanded(

--- a/frontend/test/features/weekplan/weekplan_view_test.dart
+++ b/frontend/test/features/weekplan/weekplan_view_test.dart
@@ -326,6 +326,68 @@ void main() {
       expect(find.byType(Checkbox), findsWidgets);
     });
 
+    testWidgets('Rediger button is enabled when exactly one activity selected',
+        (tester) async {
+      final activities = [
+        Activity(
+          activityId: 1,
+          date: DateTime(2026, 3, 22),
+          title: 'Morgenmad',
+        ),
+        Activity(
+          activityId: 2,
+          date: DateTime(2026, 3, 22),
+          title: 'Frokost',
+        ),
+      ];
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: activities,
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      await tester.longPress(find.text('Morgenmad'));
+      await tester.pumpAndSettle();
+
+      final rediger = find.widgetWithText(TextButton, 'Rediger');
+      expect(rediger, findsOneWidget);
+      expect(tester.widget<TextButton>(rediger).onPressed, isNotNull);
+    });
+
+    testWidgets('Rediger button is disabled when multiple activities selected',
+        (tester) async {
+      final activities = [
+        Activity(
+          activityId: 1,
+          date: DateTime(2026, 3, 22),
+          title: 'Morgenmad',
+        ),
+        Activity(
+          activityId: 2,
+          date: DateTime(2026, 3, 22),
+          title: 'Frokost',
+        ),
+      ];
+      when(() => mockCubit.state).thenReturn(WeekplanLoaded(
+        selectedDate: testDate,
+        weekDates: testWeekDates,
+        activities: activities,
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      await tester.longPress(find.text('Morgenmad'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Vælg alle'));
+      await tester.pumpAndSettle();
+
+      final rediger = find.widgetWithText(TextButton, 'Rediger');
+      expect(rediger, findsOneWidget);
+      expect(tester.widget<TextButton>(rediger).onPressed, isNull);
+    });
+
     testWidgets('close button exits selection mode', (tester) async {
       final activities = [
         Activity(


### PR DESCRIPTION
## Summary
- Long-press on a day-view tile always entered bulk-selection mode, which only offered Slet/Kopiér/Færdig — there was no way to edit an activity from the day view.
- The per-tile context menu defined in `activity_tile.dart` (`_showContextMenu` with Rediger/Slet popup items) was dead code, because the parent always provided `onLongPress` that entered selection mode.
- Add a **Rediger** button to `_SelectionActionBar`, enabled only when exactly one activity is selected. Remove the dead `_showContextMenu` method and unused `onEdit`/`onDelete` props from `ActivityTile`.

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 228/228 pass (2 new tests for Rediger enabled/disabled states)
- [ ] Manual: long-press a tile, select one activity, tap Rediger → edit form opens
- [ ] Manual: select 2+ activities, Rediger appears disabled