### PR TITLE
fix(weekplan): allow pictogram upload/generation for choice options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Upload and AI-generate pictograms directly from the pictogram picker when adding options to a choice activity (#75)
+
 ### Changed
+- Renamed the "Valgaktivitet" toggle to "Aktivitetsvælger" (#75)
 - Upgraded backend from .NET 8 to .NET 10 LTS (EOL Nov 2029)
 - Replaced Swashbuckle with built-in OpenAPI + Scalar UI (API docs now at `/scalar/v1`)
 - Bumped all NuGet packages to latest (EF Core 10, xunit 2.9, FluentAssertions 7.2)

--- a/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/activity_form_view.dart
@@ -57,7 +57,7 @@ class ActivityFormView extends StatelessWidget {
                           children: [
                             if (!state.isEditing)
                               SwitchListTile(
-                                title: const Text('Valgaktivitet'),
+                                title: const Text('Aktivitetsvælger'),
                                 subtitle: state.form.isChoiceActivity
                                     ? const Text(
                                         'Barnet vælger mellem muligheder')
@@ -456,7 +456,9 @@ class _ChoiceOptionsEditor extends StatelessWidget {
                 context: context,
                 builder: (_) => RepositoryProvider.value(
                   value: repo,
-                  child: const PictogramPickerDialog(),
+                  child: PictogramPickerDialog(
+                    organizationId: cubit.organizationId,
+                  ),
                 ),
               );
               if (picked != null) {

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_file_pickers.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_file_pickers.dart
@@ -1,0 +1,35 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import 'package:weekplanner/shared/models/file_data.dart';
+
+/// Opens the platform file picker for an image file.
+Future<FileData?> pickImageFileFromDevice() async {
+  final result = await FilePicker.platform.pickFiles(
+    type: FileType.image,
+    withData: true,
+  );
+  return _toFileData(result);
+}
+
+/// Opens the platform file picker for a sound file.
+Future<FileData?> pickSoundFileFromDevice() async {
+  final result = await FilePicker.platform.pickFiles(
+    type: FileType.custom,
+    allowedExtensions: ['mp3', 'wav', 'ogg'],
+    withData: true,
+  );
+  return _toFileData(result);
+}
+
+FileData? _toFileData(FilePickerResult? result) {
+  final file = result?.files.single;
+  if (file == null) return null;
+  return (
+    name: file.name,
+    size: file.size,
+    bytes: file.bytes,
+    // PlatformFile.path throws on web — skip it there.
+    path: kIsWeb ? null : file.path,
+  );
+}

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart
@@ -1,15 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:fpdart/fpdart.dart' show Either, Left, Right;
 
 import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/core/errors/pictogram_failure.dart';
+import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_file_pickers.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 
-/// Simplified pictogram search dialog for picking a pictogram.
+/// Pictogram picker dialog with search, upload, and AI-generate modes.
 ///
-/// Returns the selected [Pictogram], or null if dismissed.
+/// Returns the selected or newly created [Pictogram], or null if dismissed.
 class PictogramPickerDialog extends StatefulWidget {
-  const PictogramPickerDialog({super.key});
+  /// Organization to create new pictograms under.
+  final int? organizationId;
+
+  /// Overridable file pickers for testing; default to the platform picker.
+  final Future<FileData?> Function()? pickImageFile;
+  final Future<FileData?> Function()? pickSoundFile;
+
+  const PictogramPickerDialog({
+    super.key,
+    this.organizationId,
+    this.pickImageFile,
+    this.pickSoundFile,
+  });
 
   @override
   State<PictogramPickerDialog> createState() => _PictogramPickerDialogState();
@@ -17,12 +34,22 @@ class PictogramPickerDialog extends StatefulWidget {
 
 class _PictogramPickerDialogState extends State<PictogramPickerDialog> {
   final _searchController = TextEditingController();
+  final _nameController = TextEditingController();
+
+  PictogramMode _mode = PictogramMode.search;
   List<Pictogram> _results = [];
   bool _isSearching = false;
+
+  FileData? _imageFile;
+  FileData? _soundFile;
+  bool _generateSound = true;
+  bool _isCreating = false;
+  String? _error;
 
   @override
   void dispose() {
     _searchController.dispose();
+    _nameController.dispose();
     super.dispose();
   }
 
@@ -43,6 +70,82 @@ class _PictogramPickerDialogState extends State<PictogramPickerDialog> {
     });
   }
 
+  Future<void> _pickImage() async {
+    final picker = widget.pickImageFile ?? pickImageFileFromDevice;
+    final file = await picker();
+    if (file != null && mounted) setState(() => _imageFile = file);
+  }
+
+  Future<void> _pickSound() async {
+    final picker = widget.pickSoundFile ?? pickSoundFileFromDevice;
+    final file = await picker();
+    if (file != null && mounted) setState(() => _soundFile = file);
+  }
+
+  Future<void> _upload() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      setState(() => _error = 'Angiv et navn');
+      return;
+    }
+    final imageFile = _imageFile;
+    if (imageFile == null) {
+      setState(() => _error = 'Vælg et billede');
+      return;
+    }
+    setState(() {
+      _isCreating = true;
+      _error = null;
+    });
+
+    final repo = context.read<PictogramRepository>();
+    final result = await repo.uploadPictogram(
+      name: name,
+      imageFile: imageFile,
+      soundFile: _soundFile,
+      organizationId: widget.organizationId,
+      generateSound: _generateSound,
+    );
+
+    if (!mounted) return;
+    _finishCreation(result);
+  }
+
+  Future<void> _generate() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      setState(() => _error = 'Angiv et navn');
+      return;
+    }
+    setState(() {
+      _isCreating = true;
+      _error = null;
+    });
+
+    final repo = context.read<PictogramRepository>();
+    final result = await repo.createPictogram(
+      name: name,
+      organizationId: widget.organizationId,
+      generateImage: true,
+      generateSound: _generateSound,
+    );
+
+    if (!mounted) return;
+    _finishCreation(result);
+  }
+
+  void _finishCreation(Either<PictogramFailure, Pictogram> result) {
+    switch (result) {
+      case Left(:final value):
+        setState(() {
+          _isCreating = false;
+          _error = value.message;
+        });
+      case Right(:final value):
+        Navigator.of(context).pop(value);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Dialog(
@@ -60,45 +163,77 @@ class _PictogramPickerDialogState extends State<PictogramPickerDialog> {
                 style: Theme.of(context).textTheme.titleLarge,
               ),
               const SizedBox(height: GirafSpacing.md),
-              TextField(
-                controller: _searchController,
-                decoration: const InputDecoration(
-                  hintText: 'Søg piktogram',
-                  prefixIcon: Icon(Icons.search),
-                ),
-                onSubmitted: _search,
-                textInputAction: TextInputAction.search,
+              SegmentedButton<PictogramMode>(
+                segments: const [
+                  ButtonSegment(
+                    value: PictogramMode.search,
+                    label: Text('Søg'),
+                    icon: Icon(Icons.search),
+                  ),
+                  ButtonSegment(
+                    value: PictogramMode.upload,
+                    label: Text('Upload'),
+                    icon: Icon(Icons.upload_file),
+                  ),
+                  ButtonSegment(
+                    value: PictogramMode.generate,
+                    label: Text('Generer'),
+                    icon: Icon(Icons.auto_awesome),
+                  ),
+                ],
+                selected: {_mode},
+                onSelectionChanged: (modes) => setState(() {
+                  _mode = modes.first;
+                  _error = null;
+                }),
               ),
               const SizedBox(height: GirafSpacing.md),
               Flexible(
-                child: _isSearching
-                    ? const Center(child: CircularProgressIndicator())
-                    : _results.isEmpty
-                        ? Center(
-                            child: Text(
-                              'Søg for at finde piktogrammer',
-                              style: Theme.of(context).textTheme.bodyLarge,
-                            ),
-                          )
-                        : GridView.builder(
-                            shrinkWrap: true,
-                            gridDelegate:
-                                const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 3,
-                              mainAxisSpacing: GirafSpacing.sm,
-                              crossAxisSpacing: GirafSpacing.sm,
-                            ),
-                            itemCount: _results.length,
-                            itemBuilder: (context, index) {
-                              final pictogram = _results[index];
-                              return _PictogramGridItem(
-                                pictogram: pictogram,
-                                onTap: () =>
-                                    Navigator.of(context).pop(pictogram),
-                              );
-                            },
-                          ),
+                child: switch (_mode) {
+                  PictogramMode.search => _SearchContent(
+                      controller: _searchController,
+                      onSubmitted: _search,
+                      isSearching: _isSearching,
+                      results: _results,
+                      onSelect: (pictogram) =>
+                          Navigator.of(context).pop(pictogram),
+                    ),
+                  PictogramMode.upload => _CreationContent(
+                      nameController: _nameController,
+                      generateSound: _generateSound,
+                      generateSoundLabel: 'Generer lyd automatisk',
+                      isCreating: _isCreating,
+                      submitLabel: 'Opret piktogram',
+                      onGenerateSoundChanged: (value) =>
+                          setState(() => _generateSound = value),
+                      onSubmit: _upload,
+                      filePickers: _FilePickerButtons(
+                        imageFile: _imageFile,
+                        soundFile: _soundFile,
+                        onPickImage: _pickImage,
+                        onPickSound: _pickSound,
+                      ),
+                    ),
+                  PictogramMode.generate => _CreationContent(
+                      nameController: _nameController,
+                      generateSound: _generateSound,
+                      generateSoundLabel: 'Generer lyd',
+                      isCreating: _isCreating,
+                      submitLabel: 'Generer piktogram',
+                      onGenerateSoundChanged: (value) =>
+                          setState(() => _generateSound = value),
+                      onSubmit: _generate,
+                    ),
+                },
               ),
+              if (_error != null) ...[
+                const SizedBox(height: GirafSpacing.sm),
+                Text(
+                  _error!,
+                  style: TextStyle(color: context.colorScheme.error),
+                  textAlign: TextAlign.center,
+                ),
+              ],
               const SizedBox(height: GirafSpacing.sm),
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
@@ -108,6 +243,178 @@ class _PictogramPickerDialogState extends State<PictogramPickerDialog> {
           ),
         ),
       ),
+    );
+  }
+}
+
+// ── Search mode ───────────────────────────────────────────────
+
+class _SearchContent extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onSubmitted;
+  final bool isSearching;
+  final List<Pictogram> results;
+  final ValueChanged<Pictogram> onSelect;
+
+  const _SearchContent({
+    required this.controller,
+    required this.onSubmitted,
+    required this.isSearching,
+    required this.results,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: 'Søg piktogram',
+            prefixIcon: Icon(Icons.search),
+          ),
+          onSubmitted: onSubmitted,
+          textInputAction: TextInputAction.search,
+        ),
+        const SizedBox(height: GirafSpacing.md),
+        Flexible(
+          child: isSearching
+              ? const Center(child: CircularProgressIndicator())
+              : results.isEmpty
+                  ? Center(
+                      child: Text(
+                        'Søg for at finde piktogrammer',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    )
+                  : GridView.builder(
+                      shrinkWrap: true,
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        mainAxisSpacing: GirafSpacing.sm,
+                        crossAxisSpacing: GirafSpacing.sm,
+                      ),
+                      itemCount: results.length,
+                      itemBuilder: (context, index) {
+                        final pictogram = results[index];
+                        return _PictogramGridItem(
+                          pictogram: pictogram,
+                          onTap: () => onSelect(pictogram),
+                        );
+                      },
+                    ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Upload / generate modes ───────────────────────────────────
+
+/// Shared layout for the upload and generate modes: name field,
+/// optional file-picker buttons, sound toggle, and submit button.
+class _CreationContent extends StatelessWidget {
+  final TextEditingController nameController;
+  final bool generateSound;
+  final String generateSoundLabel;
+  final bool isCreating;
+  final String submitLabel;
+  final ValueChanged<bool> onGenerateSoundChanged;
+  final VoidCallback onSubmit;
+  final Widget? filePickers;
+
+  const _CreationContent({
+    required this.nameController,
+    required this.generateSound,
+    required this.generateSoundLabel,
+    required this.isCreating,
+    required this.submitLabel,
+    required this.onGenerateSoundChanged,
+    required this.onSubmit,
+    this.filePickers,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextField(
+            controller: nameController,
+            decoration: const InputDecoration(
+              labelText: 'Navn',
+              hintText: 'Navn på piktogrammet',
+              prefixIcon: Icon(Icons.edit_outlined),
+            ),
+            textCapitalization: TextCapitalization.sentences,
+          ),
+          const SizedBox(height: GirafSpacing.sm),
+          if (filePickers != null) ...[
+            filePickers!,
+            const SizedBox(height: GirafSpacing.sm),
+          ],
+          SwitchListTile(
+            title: Text(generateSoundLabel),
+            subtitle: const Text('AI-genereret udtale af navnet'),
+            value: generateSound,
+            onChanged: onGenerateSoundChanged,
+            contentPadding: EdgeInsets.zero,
+          ),
+          const SizedBox(height: GirafSpacing.sm),
+          FilledButton.icon(
+            onPressed: isCreating ? null : onSubmit,
+            icon: isCreating
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.auto_awesome),
+            label: Text(submitLabel),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilePickerButtons extends StatelessWidget {
+  final FileData? imageFile;
+  final FileData? soundFile;
+  final VoidCallback onPickImage;
+  final VoidCallback onPickSound;
+
+  const _FilePickerButtons({
+    required this.imageFile,
+    required this.soundFile,
+    required this.onPickImage,
+    required this.onPickSound,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        OutlinedButton.icon(
+          onPressed: onPickImage,
+          icon: const Icon(Icons.image),
+          label: Text(imageFile != null ? imageFile!.name : 'Vælg billede'),
+        ),
+        const SizedBox(height: GirafSpacing.sm),
+        OutlinedButton.icon(
+          onPressed: onPickSound,
+          icon: const Icon(Icons.audiotrack),
+          label: Text(
+            soundFile != null ? soundFile!.name : 'Vælg lydfil (valgfrit)',
+          ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
+++ b/frontend/lib/features/weekplan/presentation/widgets/pictogram_selector.dart
@@ -1,11 +1,10 @@
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:weekplanner/config/theme.dart';
 import 'package:weekplanner/features/weekplan/domain/activity_form_state.dart';
 import 'package:weekplanner/features/weekplan/presentation/activity_form_cubit.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_file_pickers.dart';
 import 'package:weekplanner/shared/models/file_data.dart';
 import 'package:weekplanner/shared/models/pictogram.dart';
 
@@ -261,7 +260,7 @@ class _UploadTab extends StatelessWidget {
       children: [
         OutlinedButton.icon(
           onPressed: () async {
-            final file = await _pickImageFile();
+            final file = await pickImageFileFromDevice();
             if (file != null) onImageFilePicked(file);
           },
           icon: const Icon(Icons.image),
@@ -274,7 +273,7 @@ class _UploadTab extends StatelessWidget {
         const SizedBox(height: GirafSpacing.sm),
         OutlinedButton.icon(
           onPressed: () async {
-            final file = await _pickSoundFile();
+            final file = await pickSoundFileFromDevice();
             if (file != null) onSoundFilePicked(file);
           },
           icon: const Icon(Icons.audiotrack),
@@ -296,34 +295,6 @@ class _UploadTab extends StatelessWidget {
     );
   }
 
-  Future<FileData?> _pickImageFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.image,
-      withData: true,
-    );
-    return _toFileData(result);
-  }
-
-  Future<FileData?> _pickSoundFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['mp3', 'wav', 'ogg'],
-      withData: true,
-    );
-    return _toFileData(result);
-  }
-
-  FileData? _toFileData(FilePickerResult? result) {
-    final file = result?.files.single;
-    if (file == null) return null;
-    return (
-      name: file.name,
-      size: file.size,
-      bytes: file.bytes,
-      // PlatformFile.path throws on web — skip it there.
-      path: kIsWeb ? null : file.path,
-    );
-  }
 }
 
 // ── Generate tab ──────────────────────────────────────────────

--- a/frontend/test/features/weekplan/activity_form_view_test.dart
+++ b/frontend/test/features/weekplan/activity_form_view_test.dart
@@ -48,6 +48,17 @@ void main() {
       expect(find.text('Tilføj'), findsOneWidget);
     });
 
+    testWidgets('labels the choice toggle Aktivitetsvælger', (tester) async {
+      when(() => mockCubit.state).thenReturn(ActivityFormReady(
+        form: ActivityFormData(date: testDate),
+      ));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('Aktivitetsvælger'), findsOneWidget);
+      expect(find.text('Valgaktivitet'), findsNothing);
+    });
+
     testWidgets('shows title field with current title value', (tester) async {
       when(() => mockCubit.state).thenReturn(ActivityFormReady(
         form: ActivityFormData(date: testDate, title: 'Morgenmad'),

--- a/frontend/test/features/weekplan/pictogram_picker_dialog_test.dart
+++ b/frontend/test/features/weekplan/pictogram_picker_dialog_test.dart
@@ -1,0 +1,262 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:weekplanner/config/theme.dart';
+import 'package:weekplanner/core/errors/pictogram_failure.dart';
+import 'package:weekplanner/features/weekplan/domain/repositories/pictogram_repository.dart';
+import 'package:weekplanner/features/weekplan/presentation/widgets/pictogram_picker_dialog.dart';
+import 'package:weekplanner/shared/models/file_data.dart';
+import 'package:weekplanner/shared/models/pictogram.dart';
+
+class MockPictogramRepository extends Mock implements PictogramRepository {}
+
+void main() {
+  late MockPictogramRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(
+      (name: '', size: 0, bytes: null, path: null) as FileData,
+    );
+  });
+
+  setUp(() {
+    mockRepository = MockPictogramRepository();
+  });
+
+  /// Pumps a host page with a button that opens the dialog, taps it,
+  /// and returns a getter for the dialog's pop result.
+  Future<Pictogram? Function()> openDialog(
+    WidgetTester tester, {
+    int? organizationId,
+    Future<FileData?> Function()? pickImageFile,
+  }) async {
+    Pictogram? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: girafTheme,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  result = await showDialog<Pictogram>(
+                    context: context,
+                    builder: (_) => RepositoryProvider<PictogramRepository>.value(
+                      value: mockRepository,
+                      child: PictogramPickerDialog(
+                        organizationId: organizationId,
+                        pickImageFile: pickImageFile,
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return () => result;
+  }
+
+  group('PictogramPickerDialog', () {
+    testWidgets('renders three mode segments', (tester) async {
+      await openDialog(tester);
+
+      expect(find.text('Søg'), findsOneWidget);
+      expect(find.text('Upload'), findsOneWidget);
+      expect(find.text('Generer'), findsOneWidget);
+    });
+
+    testWidgets('defaults to search mode with search field', (tester) async {
+      await openDialog(tester);
+
+      expect(
+        find.widgetWithText(TextField, 'Søg piktogram'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('upload mode shows name field, file buttons and create button',
+        (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.text('Upload'));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextField, 'Navn'), findsOneWidget);
+      expect(find.text('Vælg billede'), findsOneWidget);
+      expect(find.text('Vælg lydfil (valgfrit)'), findsOneWidget);
+      expect(find.text('Generer lyd automatisk'), findsOneWidget);
+      expect(find.text('Opret piktogram'), findsOneWidget);
+    });
+
+    testWidgets('generate mode shows name field, sound toggle and button',
+        (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.text('Generer'));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextField, 'Navn'), findsOneWidget);
+      expect(find.text('Generer lyd'), findsOneWidget);
+      expect(find.text('Generer piktogram'), findsOneWidget);
+    });
+
+    testWidgets(
+        'generate with empty name shows error and does not call repository',
+        (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.text('Generer'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Generer piktogram'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Angiv et navn'), findsOneWidget);
+      verifyNever(() => mockRepository.createPictogram(
+            name: any(named: 'name'),
+            imageUrl: any(named: 'imageUrl'),
+            organizationId: any(named: 'organizationId'),
+            generateImage: any(named: 'generateImage'),
+            generateSound: any(named: 'generateSound'),
+          ));
+    });
+
+    testWidgets('generate calls createPictogram and pops with the pictogram',
+        (tester) async {
+      const created = Pictogram(id: 7, name: 'Svømning');
+      when(() => mockRepository.createPictogram(
+            name: any(named: 'name'),
+            imageUrl: any(named: 'imageUrl'),
+            organizationId: any(named: 'organizationId'),
+            generateImage: any(named: 'generateImage'),
+            generateSound: any(named: 'generateSound'),
+          )).thenAnswer((_) async => const Right(created));
+
+      final result = await openDialog(tester, organizationId: 5);
+
+      await tester.tap(find.text('Generer'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Navn'),
+        'Svømning',
+      );
+      await tester.tap(find.text('Generer piktogram'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepository.createPictogram(
+            name: 'Svømning',
+            organizationId: 5,
+            generateImage: true,
+            generateSound: true,
+          )).called(1);
+      expect(result(), created);
+    });
+
+    testWidgets('shows error message when generation fails', (tester) async {
+      when(() => mockRepository.createPictogram(
+            name: any(named: 'name'),
+            imageUrl: any(named: 'imageUrl'),
+            organizationId: any(named: 'organizationId'),
+            generateImage: any(named: 'generateImage'),
+            generateSound: any(named: 'generateSound'),
+          )).thenAnswer(
+        (_) async => const Left(CreatePictogramFailure()),
+      );
+
+      final result = await openDialog(tester);
+
+      await tester.tap(find.text('Generer'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Navn'),
+        'Svømning',
+      );
+      await tester.tap(find.text('Generer piktogram'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Kunne ikke oprette piktogram'), findsOneWidget);
+      expect(result(), isNull);
+    });
+
+    testWidgets('upload without image shows error and does not call repository',
+        (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.text('Upload'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Navn'),
+        'Svømning',
+      );
+      await tester.tap(find.text('Opret piktogram'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Vælg et billede'), findsOneWidget);
+      verifyNever(() => mockRepository.uploadPictogram(
+            name: any(named: 'name'),
+            imageFile: any(named: 'imageFile'),
+            soundFile: any(named: 'soundFile'),
+            organizationId: any(named: 'organizationId'),
+            generateSound: any(named: 'generateSound'),
+          ));
+    });
+
+    testWidgets('upload calls uploadPictogram and pops with the pictogram',
+        (tester) async {
+      const created = Pictogram(id: 9, name: 'Svømning');
+      final imageFile = (
+        name: 'svoemning.png',
+        size: 3,
+        bytes: Uint8List.fromList([1, 2, 3]),
+        path: null,
+      );
+      when(() => mockRepository.uploadPictogram(
+            name: any(named: 'name'),
+            imageFile: any(named: 'imageFile'),
+            soundFile: any(named: 'soundFile'),
+            organizationId: any(named: 'organizationId'),
+            generateSound: any(named: 'generateSound'),
+          )).thenAnswer((_) async => const Right(created));
+
+      final result = await openDialog(
+        tester,
+        organizationId: 5,
+        pickImageFile: () async => imageFile,
+      );
+
+      await tester.tap(find.text('Upload'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Vælg billede'));
+      await tester.pumpAndSettle();
+
+      // The picked file name replaces the button label.
+      expect(find.text('svoemning.png'), findsOneWidget);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Navn'),
+        'Svømning',
+      );
+      await tester.tap(find.text('Opret piktogram'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepository.uploadPictogram(
+            name: 'Svømning',
+            imageFile: imageFile,
+            soundFile: null,
+            organizationId: 5,
+            generateSound: true,
+          )).called(1);
+      expect(result(), created);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Rename the choice-activity toggle from **Valgaktivitet** to **Aktivitetsvælger**
- Extend `PictogramPickerDialog` (used per choice option) with the same **Søg / Upload / Generer** modes as the regular pictogram selector — choice options were previously limited to existing pictograms
- New pictograms created from the dialog use a name field in the dialog (the name also becomes the option title) and are created under the caller's organization
- Extract shared file-picker helpers (`pictogram_file_pickers.dart`) reused by `PictogramSelector` and the dialog

Closes #75

## Test plan
- 10 new widget tests (TDD): mode rendering, validation errors, repository failure display, upload and generate flows popping with the created pictogram
- `flutter analyze` clean, full suite 238 tests passing