### PR TITLE
chore: suppress onReorder deprecation for Flutter 3.44 CI

### DIFF
--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -701,6 +701,9 @@ class _ActivityList extends StatelessWidget {
                 horizontal: GirafSpacing.xl,
                 vertical: GirafSpacing.lg,
               ),
+              // TODO(#82): migrate to onReorderItem once dev SDKs are on
+              // Flutter >=3.44 (onReorderItem does not exist in 3.41).
+              // ignore: deprecated_member_use
               onReorder: cubit.reorderActivities,
               proxyDecorator: (child, index, animation) =>
                   AnimatedBuilder(


### PR DESCRIPTION
CI runs Flutter stable (3.44.2) where `ReorderableListView.onReorder` is deprecated; `dart analyze --fatal-infos` fails every frontend run on main. Suppress with an ignore until dev SDKs are on >=3.44 — proper migration tracked in #82.