### PR TITLE
chore(frontend): migrate ReorderableListView to onReorderItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Renamed the "Valgaktivitet" toggle to "Aktivitetsvælger" (#75)
+- Migrated `ReorderableListView.onReorder` to `onReorderItem` — developing the frontend now requires Flutter ≥3.44 (#82)
 - Upgraded backend from .NET 8 to .NET 10 LTS (EOL Nov 2029)
 - Replaced Swashbuckle with built-in OpenAPI + Scalar UI (API docs now at `/scalar/v1`)
 - Bumped all NuGet packages to latest (EF Core 10, xunit 2.9, FluentAssertions 7.2)

--- a/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
+++ b/frontend/lib/features/weekplan/presentation/views/weekplan_view.dart
@@ -701,10 +701,7 @@ class _ActivityList extends StatelessWidget {
                 horizontal: GirafSpacing.xl,
                 vertical: GirafSpacing.lg,
               ),
-              // TODO(#82): migrate to onReorderItem once dev SDKs are on
-              // Flutter >=3.44 (onReorderItem does not exist in 3.41).
-              // ignore: deprecated_member_use
-              onReorder: cubit.reorderActivities,
+              onReorderItem: cubit.reorderActivities,
               proxyDecorator: (child, index, animation) =>
                   AnimatedBuilder(
                 animation: animation,

--- a/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
+++ b/frontend/lib/features/weekplan/presentation/weekplan_cubit.dart
@@ -206,18 +206,20 @@ class WeekplanCubit extends Cubit<WeekplanState> {
   }
 
   /// Optimistically reorder activities after a drag-and-drop.
+  ///
+  /// [newIndex] is the final position of the dragged item, as provided
+  /// by `ReorderableListView.onReorderItem` (already adjusted for the
+  /// removed slot).
   Future<void> reorderActivities(int oldIndex, int newIndex) async {
     final current = state;
     if (current is! WeekplanLoaded) return;
 
-    // ReorderableListView adjusts index when moving down
-    final adjustedNew = oldIndex < newIndex ? newIndex - 1 : newIndex;
-    if (oldIndex == adjustedNew) return;
+    if (oldIndex == newIndex) return;
 
     final backup = current.activities;
     final reordered = List<Activity>.from(backup);
     final item = reordered.removeAt(oldIndex);
-    reordered.insert(adjustedNew, item);
+    reordered.insert(newIndex, item);
 
     // Update sortOrder to match new positions
     final withSortOrder = [

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -715,10 +715,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1008,26 +1008,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -1134,4 +1134,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.0"
+  flutter: ">=3.44.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -5,6 +5,8 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.11.0
+  # ReorderableListView.onReorderItem requires Flutter >=3.44
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/frontend/test/features/weekplan/weekplan_cubit_test.dart
+++ b/frontend/test/features/weekplan/weekplan_cubit_test.dart
@@ -568,4 +568,116 @@ void main() {
       expect: () => <WeekplanState>[],
     );
   });
+
+  group('reorderActivities', () {
+    // onReorderItem semantics: newIndex is the final position of the
+    // dragged item — no index adjustment for the removed slot.
+    final a1 = testActivity.copyWith(activityId: 11, sortOrder: 0);
+    final a2 = testActivity.copyWith(activityId: 12, sortOrder: 1);
+    final a3 = testActivity.copyWith(activityId: 13, sortOrder: 2);
+
+    WeekplanLoaded loadedState() => WeekplanLoaded(
+          selectedDate: testDate,
+          weekDates: testWeekDates,
+          activities: [a1, a2, a3],
+        );
+
+    setUpAll(() {
+      registerFallbackValue(<Activity>[]);
+    });
+
+    void stubReorderSuccess() {
+      when(
+        () => mockActivityRepo.reorderActivities(
+          id: any(named: 'id'),
+          isCitizen: any(named: 'isCitizen'),
+          activities: any(named: 'activities'),
+        ),
+      ).thenAnswer((_) async => const Right(unit));
+    }
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'moves an activity down to the exact newIndex and renumbers sortOrder',
+      setUp: stubReorderSuccess,
+      build: buildCubit,
+      seed: loadedState,
+      act: (cubit) => cubit.reorderActivities(0, 1),
+      expect: () => [
+        loadedState().copyWith(activities: [
+          a2.copyWith(sortOrder: 0),
+          a1.copyWith(sortOrder: 1),
+          a3.copyWith(sortOrder: 2),
+        ]),
+      ],
+      verify: (_) {
+        verify(
+          () => mockActivityRepo.reorderActivities(
+            id: 1,
+            isCitizen: true,
+            activities: [
+              a2.copyWith(sortOrder: 0),
+              a1.copyWith(sortOrder: 1),
+              a3.copyWith(sortOrder: 2),
+            ],
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'moves an activity up to the exact newIndex',
+      setUp: stubReorderSuccess,
+      build: buildCubit,
+      seed: loadedState,
+      act: (cubit) => cubit.reorderActivities(2, 0),
+      expect: () => [
+        loadedState().copyWith(activities: [
+          a3.copyWith(sortOrder: 0),
+          a1.copyWith(sortOrder: 1),
+          a2.copyWith(sortOrder: 2),
+        ]),
+      ],
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'does nothing when the position is unchanged',
+      build: buildCubit,
+      seed: loadedState,
+      act: (cubit) => cubit.reorderActivities(1, 1),
+      expect: () => <WeekplanState>[],
+      verify: (_) {
+        verifyNever(
+          () => mockActivityRepo.reorderActivities(
+            id: any(named: 'id'),
+            isCitizen: any(named: 'isCitizen'),
+            activities: any(named: 'activities'),
+          ),
+        );
+      },
+    );
+
+    blocTest<WeekplanCubit, WeekplanState>(
+      'rolls back the optimistic reorder on repository failure',
+      setUp: () {
+        when(
+          () => mockActivityRepo.reorderActivities(
+            id: any(named: 'id'),
+            isCitizen: any(named: 'isCitizen'),
+            activities: any(named: 'activities'),
+          ),
+        ).thenAnswer((_) async => const Left(ReorderActivitiesFailure()));
+      },
+      build: buildCubit,
+      seed: loadedState,
+      act: (cubit) => cubit.reorderActivities(0, 1),
+      expect: () => [
+        loadedState().copyWith(activities: [
+          a2.copyWith(sortOrder: 0),
+          a1.copyWith(sortOrder: 1),
+          a3.copyWith(sortOrder: 2),
+        ]),
+        loadedState(),
+      ],
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `onReorder` with `onReorderItem` in `weekplan_view.dart` (removes the `// ignore: deprecated_member_use` added in #83)
- Remove the manual `newIndex` adjustment in `WeekplanCubit.reorderActivities` — `onReorderItem` already provides the final position
- Pin `flutter: ">=3.44.0"` in pubspec so older SDKs fail with a clear constraint error instead of an unknown-parameter compile error
- Add the previously missing test coverage for `reorderActivities` (move down, move up, no-op, rollback on failure)

Closes #82

## Test plan
- TDD: new tests written against `onReorderItem` semantics failed under the old adjustment logic, pass after the migration
- Verified locally on Flutter 3.44.2 (same as CI): `dart analyze --fatal-infos` clean, 242 tests passing